### PR TITLE
Remove C# to avoid error on Packagist: invalid value (C#), must match

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     "Barcode-Optimization",
     "cURL",
     ".NET",
-    "C#",
     "dotnet",
     "CSharp",
     "Java",


### PR DESCRIPTION
Remove C# to avoid error on Packagist: invalid value (C#), must match [\p{N}\p{L} ._-]+