### PR TITLE
Trim trailing empty line from README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ update:
 insert-example:
 	./scripts/insert-example.bash
 
+.PHONY: format-doc
+format-doc:
+	# Trim trailing empty line
+	sed -i -e '$${/^$$/d;}' README.md
+
 .PHONY: after-gen
-after-gen: format insert-example
+after-gen: format insert-example format-doc
 	./scripts/add-deprecation-warnings.bash


### PR DESCRIPTION
## Summary
- Add `format-doc` target to trim trailing empty line from README.md after generation

## Test plan
- [ ] Verify `make after-gen` runs successfully
- [ ] Verify README.md has no trailing empty line after generation