### PR TITLE
Release 26.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,4 @@ format-doc:
 .PHONY: after-gen
 after-gen: format insert-example format-doc
 	./scripts/add-deprecation-warnings.bash
+	./scripts/add-screaming-snake-enum-aliases.bash

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Packagist Version](https://img.shields.io/packagist/v/aspose/barcode-cloud-php)](https://packagist.org/packages/aspose/barcode-cloud-php)
 
 - API version: 4.0
-- Package version: 26.5.0
+- Package version: 26.6.0
 - Supported PHP versions: ">=8.0"
 
 ## SDK and API Version Compatibility:
@@ -66,7 +66,7 @@ require __DIR__ . '/vendor/autoload.php';
 use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
 use Aspose\BarCode\Requests\GenerateRequestWrapper;
-use Aspose\BarCode\Model\{EncodeBarcodeType, EncodeDataType, CodeLocation, BarcodeImageFormat};
+use Aspose\BarCode\Model\{EncodeBarcodeType, EncodeDataType, CodeLocation, BarcodeImageFormat, QREncodeMode, QRErrorLevel, QRVersion};
 
 $config = new Configuration();
 $config->setClientId('ClientId from https://dashboard.aspose.cloud/applications');
@@ -78,6 +78,10 @@ if (getenv("TEST_CONFIGURATION_ACCESS_TOKEN")) {
 $request = new GenerateRequestWrapper(EncodeBarcodeType::QR, 'PHP SDK Test');
 $request->image_format = BarcodeImageFormat::Png;
 $request->text_location = CodeLocation::None;
+$request->qr_encode_mode = QREncodeMode::Auto;
+$request->qr_error_level = QRErrorLevel::LevelM;
+$request->qr_version = QRVersion::Auto;
+$request->qr_aspect_ratio = 0.75;
 
 $api = new GenerateApi(null, $config);
 $response = $api->generate($request);
@@ -109,15 +113,15 @@ All URIs are relative to *<https://api.aspose.cloud/v4.0>*
 
 Class | Method | HTTP request | Description
 ----- | ------ | ------------ | -----------
-*GenerateApi* | [**generate**](docs/Api/GenerateApi.md#generate) | **GET** /barcode/generate/{barcodeType} | Generate barcode using GET request with parameters in route and query string.
-*GenerateApi* | [**generateBody**](docs/Api/GenerateApi.md#generatebody) | **POST** /barcode/generate-body | Generate barcode using POST request with parameters in body in json or xml format.
-*GenerateApi* | [**generateMultipart**](docs/Api/GenerateApi.md#generatemultipart) | **POST** /barcode/generate-multipart | Generate barcode using POST request with parameters in multipart form.
-*RecognizeApi* | [**recognize**](docs/Api/RecognizeApi.md#recognize) | **GET** /barcode/recognize | Recognize barcode from file on server in the Internet using GET requests with parameter in query string. For recognizing files from your hard drive use &#x60;recognize-body&#x60; or &#x60;recognize-multipart&#x60; endpoints instead.
-*RecognizeApi* | [**recognizeBase64**](docs/Api/RecognizeApi.md#recognizebase64) | **POST** /barcode/recognize-body | Recognize barcode from file in request body using POST requests with parameters in body in json or xml format.
-*RecognizeApi* | [**recognizeMultipart**](docs/Api/RecognizeApi.md#recognizemultipart) | **POST** /barcode/recognize-multipart | Recognize barcode from file in request body using POST requests with parameters in multipart form.
-*ScanApi* | [**scan**](docs/Api/ScanApi.md#scan) | **GET** /barcode/scan | Scan barcode from file on server in the Internet using GET requests with parameter in query string. For scaning files from your hard drive use &#x60;scan-body&#x60; or &#x60;scan-multipart&#x60; endpoints instead.
-*ScanApi* | [**scanBase64**](docs/Api/ScanApi.md#scanbase64) | **POST** /barcode/scan-body | Scan barcode from file in request body using POST requests with parameter in body in json or xml format.
-*ScanApi* | [**scanMultipart**](docs/Api/ScanApi.md#scanmultipart) | **POST** /barcode/scan-multipart | Scan barcode from file in request body using POST requests with parameter in multipart form.
+*GenerateApi* | [**generate**](docs/Api/GenerateApi.md#generate) | **GET** /barcode/generate/{barcodeType} | Generate a barcode using a GET request with parameters in the route and query string.
+*GenerateApi* | [**generateBody**](docs/Api/GenerateApi.md#generatebody) | **POST** /barcode/generate-body | Generate a barcode using a POST request with parameters in the request body in JSON or XML format.
+*GenerateApi* | [**generateMultipart**](docs/Api/GenerateApi.md#generatemultipart) | **POST** /barcode/generate-multipart | Generate a barcode using a POST request with parameters in a multipart form.
+*RecognizeApi* | [**recognize**](docs/Api/RecognizeApi.md#recognize) | **GET** /barcode/recognize | Recognize a barcode from a file on an Internet server using a GET request with a query string parameter. For recognizing files from your hard drive, use &#x60;recognize-body&#x60; or &#x60;recognize-multipart&#x60; endpoints instead.
+*RecognizeApi* | [**recognizeBase64**](docs/Api/RecognizeApi.md#recognizebase64) | **POST** /barcode/recognize-body | Recognize a barcode from a file in the request body using a POST request with JSON or XML body parameters.
+*RecognizeApi* | [**recognizeMultipart**](docs/Api/RecognizeApi.md#recognizemultipart) | **POST** /barcode/recognize-multipart | Recognize a barcode from a file in the request body using a POST request with multipart form parameters.
+*ScanApi* | [**scan**](docs/Api/ScanApi.md#scan) | **GET** /barcode/scan | Scan a barcode from a file on an Internet server using a GET request with a query string parameter. For scanning files from your hard drive, use &#x60;scan-body&#x60; or &#x60;scan-multipart&#x60; endpoints instead.
+*ScanApi* | [**scanBase64**](docs/Api/ScanApi.md#scanbase64) | **POST** /barcode/scan-body | Scan a barcode from a file in the request body using a POST request with a JSON or XML body parameter.
+*ScanApi* | [**scanMultipart**](docs/Api/ScanApi.md#scanmultipart) | **POST** /barcode/scan-multipart | Scan a barcode from a file in the request body using a POST request with a multipart form parameter.
 
 ## Documentation For Models
 
@@ -127,15 +131,28 @@ Class | Method | HTTP request | Description
 - [BarcodeImageParams](docs/Model/BarcodeImageParams.md)
 - [BarcodeResponse](docs/Model/BarcodeResponse.md)
 - [BarcodeResponseList](docs/Model/BarcodeResponseList.md)
+- [Code128EncodeMode](docs/Model/Code128EncodeMode.md)
+- [Code128Params](docs/Model/Code128Params.md)
 - [CodeLocation](docs/Model/CodeLocation.md)
 - [DecodeBarcodeType](docs/Model/DecodeBarcodeType.md)
+- [ECIEncodings](docs/Model/ECIEncodings.md)
 - [EncodeBarcodeType](docs/Model/EncodeBarcodeType.md)
 - [EncodeData](docs/Model/EncodeData.md)
 - [EncodeDataType](docs/Model/EncodeDataType.md)
 - [GenerateParams](docs/Model/GenerateParams.md)
 - [GraphicsUnit](docs/Model/GraphicsUnit.md)
+- [MacroCharacter](docs/Model/MacroCharacter.md)
+- [MicroQRVersion](docs/Model/MicroQRVersion.md)
+- [Pdf417EncodeMode](docs/Model/Pdf417EncodeMode.md)
+- [Pdf417ErrorLevel](docs/Model/Pdf417ErrorLevel.md)
+- [Pdf417Params](docs/Model/Pdf417Params.md)
+- [QREncodeMode](docs/Model/QREncodeMode.md)
+- [QRErrorLevel](docs/Model/QRErrorLevel.md)
+- [QRVersion](docs/Model/QRVersion.md)
+- [QrParams](docs/Model/QrParams.md)
 - [RecognitionImageKind](docs/Model/RecognitionImageKind.md)
 - [RecognitionMode](docs/Model/RecognitionMode.md)
 - [RecognizeBase64Request](docs/Model/RecognizeBase64Request.md)
+- [RectMicroQRVersion](docs/Model/RectMicroQRVersion.md)
 - [RegionPoint](docs/Model/RegionPoint.md)
 - [ScanBase64Request](docs/Model/ScanBase64Request.md)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ require __DIR__ . '/vendor/autoload.php';
 use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
 use Aspose\BarCode\Requests\GenerateRequestWrapper;
-use Aspose\BarCode\Model\{EncodeBarcodeType, EncodeDataType, CodeLocation, BarcodeImageFormat, QREncodeMode, QRErrorLevel, QRVersion};
+use Aspose\BarCode\Model\{BarcodeImageParams, EncodeBarcodeType, EncodeDataType, CodeLocation, BarcodeImageFormat, QrParams, QREncodeMode, QRErrorLevel, QRVersion};
 
 $config = new Configuration();
 $config->setClientId('ClientId from https://dashboard.aspose.cloud/applications');
@@ -76,12 +76,14 @@ if (getenv("TEST_CONFIGURATION_ACCESS_TOKEN")) {
 }
 
 $request = new GenerateRequestWrapper(EncodeBarcodeType::QR, 'PHP SDK Test');
-$request->image_format = BarcodeImageFormat::Png;
-$request->text_location = CodeLocation::None;
-$request->qr_encode_mode = QREncodeMode::Auto;
-$request->qr_error_level = QRErrorLevel::LevelM;
-$request->qr_version = QRVersion::Auto;
-$request->qr_aspect_ratio = 0.75;
+$request->barcode_image_params = new BarcodeImageParams();
+$request->barcode_image_params->setImageFormat(BarcodeImageFormat::Png);
+$request->barcode_image_params->setTextLocation(CodeLocation::None);
+$request->qr_params = new QrParams();
+$request->qr_params->setQrEncodeMode(QREncodeMode::Auto);
+$request->qr_params->setQrErrorLevel(QRErrorLevel::LevelM);
+$request->qr_params->setQrVersion(QRVersion::Auto);
+$request->qr_params->setQrAspectRatio(0.75);
 
 $api = new GenerateApi(null, $config);
 $response = $api->generate($request);

--- a/docs/Api/GenerateApi.md
+++ b/docs/Api/GenerateApi.md
@@ -6,18 +6,18 @@ All URIs are relative to https://api.aspose.cloud/v4.0, except if the operation 
 
 | Method | HTTP request | Description |
 | ------------- | ------------- | ------------- |
-| [**generate()**](GenerateApi.md#generate) | **GET** /barcode/generate/{barcodeType} | Generate barcode using GET request with parameters in route and query string. |
-| [**generateBody()**](GenerateApi.md#generateBody) | **POST** /barcode/generate-body | Generate barcode using POST request with parameters in body in json or xml format. |
-| [**generateMultipart()**](GenerateApi.md#generateMultipart) | **POST** /barcode/generate-multipart | Generate barcode using POST request with parameters in multipart form. |
+| [**generate()**](GenerateApi.md#generate) | **GET** /barcode/generate/{barcodeType} | Generate a barcode using a GET request with parameters in the route and query string. |
+| [**generateBody()**](GenerateApi.md#generateBody) | **POST** /barcode/generate-body | Generate a barcode using a POST request with parameters in the request body in JSON or XML format. |
+| [**generateMultipart()**](GenerateApi.md#generateMultipart) | **POST** /barcode/generate-multipart | Generate a barcode using a POST request with parameters in a multipart form. |
 
 
 ## `generate()`
 
 ```php
-generate($barcode_type, $data, $data_type, $image_format, $text_location, $foreground_color, $background_color, $units, $resolution, $image_height, $image_width, $rotation_angle): \SplFileObject
+generate($barcode_type, $data, $data_type, $image_format, $text_location, $foreground_color, $background_color, $units, $resolution, $image_height, $image_width, $rotation_angle, $qr_encode_mode, $qr_error_level, $qr_version, $qr_eci_encoding, $qr_aspect_ratio, $micro_qr_version, $rect_micro_qr_version, $code128_encode_mode, $pdf417_encode_mode, $pdf417_error_level, $pdf417_truncate, $pdf417_columns, $pdf417_rows, $pdf417_aspect_ratio, $pdf417_eci_encoding, $pdf417_is_reader_initialization, $pdf417_macro_characters, $pdf417_is_linked, $pdf417_is_code128_emulation): \SplFileObject
 ```
 
-Generate barcode using GET request with parameters in route and query string.
+Generate a barcode using a GET request with parameters in the route and query string.
 
 ### Example
 
@@ -37,20 +37,39 @@ $apiInstance = new Aspose\BarCode\Api\GenerateApi(
     $config
 );
 $barcode_type = new \Aspose\BarCode\Model\EncodeBarcodeType(); // \Aspose\BarCode\Model\EncodeBarcodeType | Type of barcode to generate.
-$data = 'data_example'; // string | String represents data to encode
+$data = 'data_example'; // string | String that represents the data to encode.
 $data_type = new \Aspose\BarCode\Model\EncodeDataType(); // \Aspose\BarCode\Model\EncodeDataType | Type of data to encode. Default value: StringData.
-$image_format = new \Aspose\BarCode\Model\BarcodeImageFormat(); // \Aspose\BarCode\Model\BarcodeImageFormat | Barcode output image format. Default value: png
-$text_location = new \Aspose\BarCode\Model\CodeLocation(); // \Aspose\BarCode\Model\CodeLocation | Specify the displaying Text Location, set to CodeLocation.None to hide CodeText. Default value: Depends on BarcodeType. CodeLocation.Below for 1D Barcodes. CodeLocation.None for 2D Barcodes.
-$foreground_color = 'Black'; // string | Specify the displaying bars and content Color. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: Black.
-$background_color = 'White'; // string | Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: White.
-$units = new \Aspose\BarCode\Model\GraphicsUnit(); // \Aspose\BarCode\Model\GraphicsUnit | Common Units for all measuring in query. Default units: pixel.
-$resolution = 3.4; // float | Resolution of the BarCode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is dot.
-$image_height = 3.4; // float | Height of the barcode image in given units. Default units: pixel. Decimal separator is dot.
-$image_width = 3.4; // float | Width of the barcode image in given units. Default units: pixel. Decimal separator is dot.
-$rotation_angle = 56; // int | BarCode image rotation angle, measured in degree, e.g. RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle NOT equal to 90, 180, 270 or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
+$image_format = new \Aspose\BarCode\Model\BarcodeImageFormat(); // \Aspose\BarCode\Model\BarcodeImageFormat | Barcode output image format. Default value: png.
+$text_location = new \Aspose\BarCode\Model\CodeLocation(); // \Aspose\BarCode\Model\CodeLocation | Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes.
+$foreground_color = 'Black'; // string | Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
+$background_color = 'White'; // string | Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
+$units = new \Aspose\BarCode\Model\GraphicsUnit(); // \Aspose\BarCode\Model\GraphicsUnit | Common units for all measurements. Default units: pixels.
+$resolution = 3.4; // float | Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
+$image_height = 3.4; // float | Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
+$image_width = 3.4; // float | Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
+$rotation_angle = 56; // int | Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
+$qr_encode_mode = new \Aspose\BarCode\Model\QREncodeMode(); // \Aspose\BarCode\Model\QREncodeMode | QR barcode encode mode.
+$qr_error_level = new \Aspose\BarCode\Model\QRErrorLevel(); // \Aspose\BarCode\Model\QRErrorLevel | QR barcode error correction level.
+$qr_version = new \Aspose\BarCode\Model\QRVersion(); // \Aspose\BarCode\Model\QRVersion | QR barcode version. Automatically selects the smallest version that fits the data.
+$qr_eci_encoding = new \Aspose\BarCode\Model\ECIEncodings(); // \Aspose\BarCode\Model\ECIEncodings | ECI encoding for QR barcode data.
+$qr_aspect_ratio = 3.4; // float | QR barcode aspect ratio. Values: 0 to 1.
+$micro_qr_version = new \Aspose\BarCode\Model\MicroQRVersion(); // \Aspose\BarCode\Model\MicroQRVersion | MicroQR barcode version. Used when BarcodeType is MicroQR.
+$rect_micro_qr_version = new \Aspose\BarCode\Model\RectMicroQRVersion(); // \Aspose\BarCode\Model\RectMicroQRVersion | RectMicroQR barcode version. Used when BarcodeType is RectMicroQR.
+$code128_encode_mode = new \Aspose\BarCode\Model\Code128EncodeMode(); // \Aspose\BarCode\Model\Code128EncodeMode | Code128 barcode encode mode. Controls which Code 128 subset (A, B, C, or mix) is used.
+$pdf417_encode_mode = new \Aspose\BarCode\Model\Pdf417EncodeMode(); // \Aspose\BarCode\Model\Pdf417EncodeMode | PDF417 barcode encode mode.
+$pdf417_error_level = new \Aspose\BarCode\Model\Pdf417ErrorLevel(); // \Aspose\BarCode\Model\Pdf417ErrorLevel | PDF417 barcode error correction level.
+$pdf417_truncate = True; // bool | Whether to use truncated PDF417 format (removes right-side stop pattern).
+$pdf417_columns = 56; // int | Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
+$pdf417_rows = 56; // int | Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
+$pdf417_aspect_ratio = 3.4; // float | PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
+$pdf417_eci_encoding = new \Aspose\BarCode\Model\ECIEncodings(); // \Aspose\BarCode\Model\ECIEncodings | ECI encoding for PDF417 barcode data.
+$pdf417_is_reader_initialization = True; // bool | Whether the barcode is used for reader initialization (programming).
+$pdf417_macro_characters = new \Aspose\BarCode\Model\MacroCharacter(); // \Aspose\BarCode\Model\MacroCharacter | Macro character to prepend (structured append).
+$pdf417_is_linked = True; // bool | Whether to use linked mode (for MicroPdf417).
+$pdf417_is_code128_emulation = True; // bool | Whether to use Code128 emulation for MicroPdf417.
 
 try {
-    $result = $apiInstance->generate($barcode_type, $data, $data_type, $image_format, $text_location, $foreground_color, $background_color, $units, $resolution, $image_height, $image_width, $rotation_angle);
+    $result = $apiInstance->generate($barcode_type, $data, $data_type, $image_format, $text_location, $foreground_color, $background_color, $units, $resolution, $image_height, $image_width, $rotation_angle, $qr_encode_mode, $qr_error_level, $qr_version, $qr_eci_encoding, $qr_aspect_ratio, $micro_qr_version, $rect_micro_qr_version, $code128_encode_mode, $pdf417_encode_mode, $pdf417_error_level, $pdf417_truncate, $pdf417_columns, $pdf417_rows, $pdf417_aspect_ratio, $pdf417_eci_encoding, $pdf417_is_reader_initialization, $pdf417_macro_characters, $pdf417_is_linked, $pdf417_is_code128_emulation);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling GenerateApi->generate: ', $e->getMessage(), PHP_EOL;
@@ -62,17 +81,36 @@ try {
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **barcode_type** | [**\Aspose\BarCode\Model\EncodeBarcodeType**](../Model/.md)| Type of barcode to generate. | |
-| **data** | **string**| String represents data to encode | |
+| **data** | **string**| String that represents the data to encode. | |
 | **data_type** | [**\Aspose\BarCode\Model\EncodeDataType**](../Model/.md)| Type of data to encode. Default value: StringData. | [optional] |
-| **image_format** | [**\Aspose\BarCode\Model\BarcodeImageFormat**](../Model/.md)| Barcode output image format. Default value: png | [optional] |
-| **text_location** | [**\Aspose\BarCode\Model\CodeLocation**](../Model/.md)| Specify the displaying Text Location, set to CodeLocation.None to hide CodeText. Default value: Depends on BarcodeType. CodeLocation.Below for 1D Barcodes. CodeLocation.None for 2D Barcodes. | [optional] |
-| **foreground_color** | **string**| Specify the displaying bars and content Color. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: Black. | [optional] [default to &#39;Black&#39;] |
-| **background_color** | **string**| Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: White. | [optional] [default to &#39;White&#39;] |
-| **units** | [**\Aspose\BarCode\Model\GraphicsUnit**](../Model/.md)| Common Units for all measuring in query. Default units: pixel. | [optional] |
-| **resolution** | **float**| Resolution of the BarCode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is dot. | [optional] |
-| **image_height** | **float**| Height of the barcode image in given units. Default units: pixel. Decimal separator is dot. | [optional] |
-| **image_width** | **float**| Width of the barcode image in given units. Default units: pixel. Decimal separator is dot. | [optional] |
-| **rotation_angle** | **int**| BarCode image rotation angle, measured in degree, e.g. RotationAngle &#x3D; 0 or RotationAngle &#x3D; 360 means no rotation. If RotationAngle NOT equal to 90, 180, 270 or 0, it may increase the difficulty for the scanner to read the image. Default value: 0. | [optional] |
+| **image_format** | [**\Aspose\BarCode\Model\BarcodeImageFormat**](../Model/.md)| Barcode output image format. Default value: png. | [optional] |
+| **text_location** | [**\Aspose\BarCode\Model\CodeLocation**](../Model/.md)| Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes. | [optional] |
+| **foreground_color** | **string**| Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black. | [optional] [default to &#39;Black&#39;] |
+| **background_color** | **string**| Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White. | [optional] [default to &#39;White&#39;] |
+| **units** | [**\Aspose\BarCode\Model\GraphicsUnit**](../Model/.md)| Common units for all measurements. Default units: pixels. | [optional] |
+| **resolution** | **float**| Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot. | [optional] |
+| **image_height** | **float**| Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot. | [optional] |
+| **image_width** | **float**| Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot. | [optional] |
+| **rotation_angle** | **int**| Barcode image rotation angle, measured in degrees. For example, RotationAngle &#x3D; 0 or RotationAngle &#x3D; 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0. | [optional] |
+| **qr_encode_mode** | [**\Aspose\BarCode\Model\QREncodeMode**](../Model/.md)| QR barcode encode mode. | [optional] |
+| **qr_error_level** | [**\Aspose\BarCode\Model\QRErrorLevel**](../Model/.md)| QR barcode error correction level. | [optional] |
+| **qr_version** | [**\Aspose\BarCode\Model\QRVersion**](../Model/.md)| QR barcode version. Automatically selects the smallest version that fits the data. | [optional] |
+| **qr_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](../Model/.md)| ECI encoding for QR barcode data. | [optional] |
+| **qr_aspect_ratio** | **float**| QR barcode aspect ratio. Values: 0 to 1. | [optional] |
+| **micro_qr_version** | [**\Aspose\BarCode\Model\MicroQRVersion**](../Model/.md)| MicroQR barcode version. Used when BarcodeType is MicroQR. | [optional] |
+| **rect_micro_qr_version** | [**\Aspose\BarCode\Model\RectMicroQRVersion**](../Model/.md)| RectMicroQR barcode version. Used when BarcodeType is RectMicroQR. | [optional] |
+| **code128_encode_mode** | [**\Aspose\BarCode\Model\Code128EncodeMode**](../Model/.md)| Code128 barcode encode mode. Controls which Code 128 subset (A, B, C, or mix) is used. | [optional] |
+| **pdf417_encode_mode** | [**\Aspose\BarCode\Model\Pdf417EncodeMode**](../Model/.md)| PDF417 barcode encode mode. | [optional] |
+| **pdf417_error_level** | [**\Aspose\BarCode\Model\Pdf417ErrorLevel**](../Model/.md)| PDF417 barcode error correction level. | [optional] |
+| **pdf417_truncate** | **bool**| Whether to use truncated PDF417 format (removes right-side stop pattern). | [optional] |
+| **pdf417_columns** | **int**| Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto. | [optional] |
+| **pdf417_rows** | **int**| Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic. | [optional] |
+| **pdf417_aspect_ratio** | **float**| PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417. | [optional] |
+| **pdf417_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](../Model/.md)| ECI encoding for PDF417 barcode data. | [optional] |
+| **pdf417_is_reader_initialization** | **bool**| Whether the barcode is used for reader initialization (programming). | [optional] |
+| **pdf417_macro_characters** | [**\Aspose\BarCode\Model\MacroCharacter**](../Model/.md)| Macro character to prepend (structured append). | [optional] |
+| **pdf417_is_linked** | **bool**| Whether to use linked mode (for MicroPdf417). | [optional] |
+| **pdf417_is_code128_emulation** | **bool**| Whether to use Code128 emulation for MicroPdf417. | [optional] |
 
 ### Return type
 
@@ -97,7 +135,7 @@ try {
 generateBody($generate_params): \SplFileObject
 ```
 
-Generate barcode using POST request with parameters in body in json or xml format.
+Generate a barcode using a POST request with parameters in the request body in JSON or XML format.
 
 ### Example
 
@@ -116,7 +154,7 @@ $apiInstance = new Aspose\BarCode\Api\GenerateApi(
     new GuzzleHttp\Client(),
     $config
 );
-$generate_params = new \Aspose\BarCode\Model\GenerateParams(); // \Aspose\BarCode\Model\GenerateParams | Parameters of generation
+$generate_params = new \Aspose\BarCode\Model\GenerateParams(); // \Aspose\BarCode\Model\GenerateParams | Generation parameters.
 
 try {
     $result = $apiInstance->generateBody($generate_params);
@@ -130,7 +168,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **generate_params** | [**\Aspose\BarCode\Model\GenerateParams**](../Model/GenerateParams.md)| Parameters of generation | |
+| **generate_params** | [**\Aspose\BarCode\Model\GenerateParams**](../Model/GenerateParams.md)| Generation parameters. | |
 
 ### Return type
 
@@ -152,10 +190,10 @@ try {
 ## `generateMultipart()`
 
 ```php
-generateMultipart($barcode_type, $data, $data_type, $image_format, $text_location, $foreground_color, $background_color, $units, $resolution, $image_height, $image_width, $rotation_angle): \SplFileObject
+generateMultipart($barcode_type, $data, $data_type, $image_format, $text_location, $foreground_color, $background_color, $units, $resolution, $image_height, $image_width, $rotation_angle, $qr_encode_mode, $qr_error_level, $qr_version, $qr_eci_encoding, $qr_aspect_ratio, $micro_qr_version, $rect_micro_qr_version, $code128_encode_mode, $pdf417_encode_mode, $pdf417_error_level, $pdf417_truncate, $pdf417_columns, $pdf417_rows, $pdf417_aspect_ratio, $pdf417_eci_encoding, $pdf417_is_reader_initialization, $pdf417_macro_characters, $pdf417_is_linked, $pdf417_is_code128_emulation): \SplFileObject
 ```
 
-Generate barcode using POST request with parameters in multipart form.
+Generate a barcode using a POST request with parameters in a multipart form.
 
 ### Example
 
@@ -175,20 +213,39 @@ $apiInstance = new Aspose\BarCode\Api\GenerateApi(
     $config
 );
 $barcode_type = new \Aspose\BarCode\Model\EncodeBarcodeType(); // \Aspose\BarCode\Model\EncodeBarcodeType
-$data = 'data_example'; // string | String represents data to encode
+$data = 'data_example'; // string | String that represents the data to encode.
 $data_type = new \Aspose\BarCode\Model\EncodeDataType(); // \Aspose\BarCode\Model\EncodeDataType
 $image_format = new \Aspose\BarCode\Model\BarcodeImageFormat(); // \Aspose\BarCode\Model\BarcodeImageFormat
 $text_location = new \Aspose\BarCode\Model\CodeLocation(); // \Aspose\BarCode\Model\CodeLocation
-$foreground_color = 'Black'; // string | Specify the displaying bars and content Color. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: Black.
-$background_color = 'White'; // string | Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: White.
+$foreground_color = 'Black'; // string | Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
+$background_color = 'White'; // string | Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
 $units = new \Aspose\BarCode\Model\GraphicsUnit(); // \Aspose\BarCode\Model\GraphicsUnit
-$resolution = 3.4; // float | Resolution of the BarCode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is dot.
-$image_height = 3.4; // float | Height of the barcode image in given units. Default units: pixel. Decimal separator is dot.
-$image_width = 3.4; // float | Width of the barcode image in given units. Default units: pixel. Decimal separator is dot.
-$rotation_angle = 56; // int | BarCode image rotation angle, measured in degree, e.g. RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle NOT equal to 90, 180, 270 or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
+$resolution = 3.4; // float | Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
+$image_height = 3.4; // float | Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
+$image_width = 3.4; // float | Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
+$rotation_angle = 56; // int | Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
+$qr_encode_mode = new \Aspose\BarCode\Model\QREncodeMode(); // \Aspose\BarCode\Model\QREncodeMode
+$qr_error_level = new \Aspose\BarCode\Model\QRErrorLevel(); // \Aspose\BarCode\Model\QRErrorLevel
+$qr_version = new \Aspose\BarCode\Model\QRVersion(); // \Aspose\BarCode\Model\QRVersion
+$qr_eci_encoding = new \Aspose\BarCode\Model\ECIEncodings(); // \Aspose\BarCode\Model\ECIEncodings
+$qr_aspect_ratio = 3.4; // float | QR barcode aspect ratio. Values: 0 to 1.
+$micro_qr_version = new \Aspose\BarCode\Model\MicroQRVersion(); // \Aspose\BarCode\Model\MicroQRVersion
+$rect_micro_qr_version = new \Aspose\BarCode\Model\RectMicroQRVersion(); // \Aspose\BarCode\Model\RectMicroQRVersion
+$code128_encode_mode = new \Aspose\BarCode\Model\Code128EncodeMode(); // \Aspose\BarCode\Model\Code128EncodeMode
+$pdf417_encode_mode = new \Aspose\BarCode\Model\Pdf417EncodeMode(); // \Aspose\BarCode\Model\Pdf417EncodeMode
+$pdf417_error_level = new \Aspose\BarCode\Model\Pdf417ErrorLevel(); // \Aspose\BarCode\Model\Pdf417ErrorLevel
+$pdf417_truncate = True; // bool | Whether to use truncated PDF417 format (removes right-side stop pattern).
+$pdf417_columns = 56; // int | Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
+$pdf417_rows = 56; // int | Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
+$pdf417_aspect_ratio = 3.4; // float | PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
+$pdf417_eci_encoding = new \Aspose\BarCode\Model\ECIEncodings(); // \Aspose\BarCode\Model\ECIEncodings
+$pdf417_is_reader_initialization = True; // bool | Whether the barcode is used for reader initialization (programming).
+$pdf417_macro_characters = new \Aspose\BarCode\Model\MacroCharacter(); // \Aspose\BarCode\Model\MacroCharacter
+$pdf417_is_linked = True; // bool | Whether to use linked mode (for MicroPdf417).
+$pdf417_is_code128_emulation = True; // bool | Whether to use Code128 emulation for MicroPdf417.
 
 try {
-    $result = $apiInstance->generateMultipart($barcode_type, $data, $data_type, $image_format, $text_location, $foreground_color, $background_color, $units, $resolution, $image_height, $image_width, $rotation_angle);
+    $result = $apiInstance->generateMultipart($barcode_type, $data, $data_type, $image_format, $text_location, $foreground_color, $background_color, $units, $resolution, $image_height, $image_width, $rotation_angle, $qr_encode_mode, $qr_error_level, $qr_version, $qr_eci_encoding, $qr_aspect_ratio, $micro_qr_version, $rect_micro_qr_version, $code128_encode_mode, $pdf417_encode_mode, $pdf417_error_level, $pdf417_truncate, $pdf417_columns, $pdf417_rows, $pdf417_aspect_ratio, $pdf417_eci_encoding, $pdf417_is_reader_initialization, $pdf417_macro_characters, $pdf417_is_linked, $pdf417_is_code128_emulation);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling GenerateApi->generateMultipart: ', $e->getMessage(), PHP_EOL;
@@ -200,17 +257,36 @@ try {
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **barcode_type** | [**\Aspose\BarCode\Model\EncodeBarcodeType**](../Model/EncodeBarcodeType.md)|  | |
-| **data** | **string**| String represents data to encode | |
+| **data** | **string**| String that represents the data to encode. | |
 | **data_type** | [**\Aspose\BarCode\Model\EncodeDataType**](../Model/EncodeDataType.md)|  | [optional] |
 | **image_format** | [**\Aspose\BarCode\Model\BarcodeImageFormat**](../Model/BarcodeImageFormat.md)|  | [optional] |
 | **text_location** | [**\Aspose\BarCode\Model\CodeLocation**](../Model/CodeLocation.md)|  | [optional] |
-| **foreground_color** | **string**| Specify the displaying bars and content Color. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: Black. | [optional] [default to &#39;Black&#39;] |
-| **background_color** | **string**| Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: White. | [optional] [default to &#39;White&#39;] |
+| **foreground_color** | **string**| Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black. | [optional] [default to &#39;Black&#39;] |
+| **background_color** | **string**| Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White. | [optional] [default to &#39;White&#39;] |
 | **units** | [**\Aspose\BarCode\Model\GraphicsUnit**](../Model/GraphicsUnit.md)|  | [optional] |
-| **resolution** | **float**| Resolution of the BarCode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is dot. | [optional] |
-| **image_height** | **float**| Height of the barcode image in given units. Default units: pixel. Decimal separator is dot. | [optional] |
-| **image_width** | **float**| Width of the barcode image in given units. Default units: pixel. Decimal separator is dot. | [optional] |
-| **rotation_angle** | **int**| BarCode image rotation angle, measured in degree, e.g. RotationAngle &#x3D; 0 or RotationAngle &#x3D; 360 means no rotation. If RotationAngle NOT equal to 90, 180, 270 or 0, it may increase the difficulty for the scanner to read the image. Default value: 0. | [optional] |
+| **resolution** | **float**| Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot. | [optional] |
+| **image_height** | **float**| Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot. | [optional] |
+| **image_width** | **float**| Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot. | [optional] |
+| **rotation_angle** | **int**| Barcode image rotation angle, measured in degrees. For example, RotationAngle &#x3D; 0 or RotationAngle &#x3D; 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0. | [optional] |
+| **qr_encode_mode** | [**\Aspose\BarCode\Model\QREncodeMode**](../Model/QREncodeMode.md)|  | [optional] |
+| **qr_error_level** | [**\Aspose\BarCode\Model\QRErrorLevel**](../Model/QRErrorLevel.md)|  | [optional] |
+| **qr_version** | [**\Aspose\BarCode\Model\QRVersion**](../Model/QRVersion.md)|  | [optional] |
+| **qr_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](../Model/ECIEncodings.md)|  | [optional] |
+| **qr_aspect_ratio** | **float**| QR barcode aspect ratio. Values: 0 to 1. | [optional] |
+| **micro_qr_version** | [**\Aspose\BarCode\Model\MicroQRVersion**](../Model/MicroQRVersion.md)|  | [optional] |
+| **rect_micro_qr_version** | [**\Aspose\BarCode\Model\RectMicroQRVersion**](../Model/RectMicroQRVersion.md)|  | [optional] |
+| **code128_encode_mode** | [**\Aspose\BarCode\Model\Code128EncodeMode**](../Model/Code128EncodeMode.md)|  | [optional] |
+| **pdf417_encode_mode** | [**\Aspose\BarCode\Model\Pdf417EncodeMode**](../Model/Pdf417EncodeMode.md)|  | [optional] |
+| **pdf417_error_level** | [**\Aspose\BarCode\Model\Pdf417ErrorLevel**](../Model/Pdf417ErrorLevel.md)|  | [optional] |
+| **pdf417_truncate** | **bool**| Whether to use truncated PDF417 format (removes right-side stop pattern). | [optional] |
+| **pdf417_columns** | **int**| Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto. | [optional] |
+| **pdf417_rows** | **int**| Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic. | [optional] |
+| **pdf417_aspect_ratio** | **float**| PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417. | [optional] |
+| **pdf417_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](../Model/ECIEncodings.md)|  | [optional] |
+| **pdf417_is_reader_initialization** | **bool**| Whether the barcode is used for reader initialization (programming). | [optional] |
+| **pdf417_macro_characters** | [**\Aspose\BarCode\Model\MacroCharacter**](../Model/MacroCharacter.md)|  | [optional] |
+| **pdf417_is_linked** | **bool**| Whether to use linked mode (for MicroPdf417). | [optional] |
+| **pdf417_is_code128_emulation** | **bool**| Whether to use Code128 emulation for MicroPdf417. | [optional] |
 
 ### Return type
 

--- a/docs/Api/GenerateApi.md
+++ b/docs/Api/GenerateApi.md
@@ -36,10 +36,10 @@ $apiInstance = new Aspose\BarCode\Api\GenerateApi(
     new GuzzleHttp\Client(),
     $config
 );
-$barcode_type = new \Aspose\BarCode\Model\EncodeBarcodeType(); // \Aspose\BarCode\Model\EncodeBarcodeType | Type of barcode to generate.
+$barcode_type = new \Aspose\BarCode\Model\\AsposeBarCodeModelEncodeBarcodeType(); // \AsposeBarCodeModelEncodeBarcodeType | Type of barcode to generate.
 $data = 'data_example'; // string | String that represents the data to encode.
-$data_type = new \Aspose\BarCode\Model\EncodeDataType(); // \Aspose\BarCode\Model\EncodeDataType | Type of data to encode. Default value: StringData.
-$image_format = new \Aspose\BarCode\Model\BarcodeImageFormat(); // \Aspose\BarCode\Model\BarcodeImageFormat | Barcode output image format. Default value: png.
+$data_type = new \Aspose\BarCode\Model\\AsposeBarCodeModelEncodeDataType(); // \AsposeBarCodeModelEncodeDataType | Type of data to encode. Default value: StringData.
+$image_format = new \Aspose\BarCode\Model\\AsposeBarCodeModelBarcodeImageFormat(); // \AsposeBarCodeModelBarcodeImageFormat | Barcode output image format. Default value: png.
 $text_location = new \Aspose\BarCode\Model\CodeLocation(); // \Aspose\BarCode\Model\CodeLocation | Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes.
 $foreground_color = 'Black'; // string | Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
 $background_color = 'White'; // string | Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
@@ -80,10 +80,10 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **barcode_type** | [**\Aspose\BarCode\Model\EncodeBarcodeType**](../Model/.md)| Type of barcode to generate. | |
+| **barcode_type** | [**\AsposeBarCodeModelEncodeBarcodeType**](../Model/.md)| Type of barcode to generate. | |
 | **data** | **string**| String that represents the data to encode. | |
-| **data_type** | [**\Aspose\BarCode\Model\EncodeDataType**](../Model/.md)| Type of data to encode. Default value: StringData. | [optional] |
-| **image_format** | [**\Aspose\BarCode\Model\BarcodeImageFormat**](../Model/.md)| Barcode output image format. Default value: png. | [optional] |
+| **data_type** | [**\AsposeBarCodeModelEncodeDataType**](../Model/.md)| Type of data to encode. Default value: StringData. | [optional] [default to &#39;StringData&#39;] |
+| **image_format** | [**\AsposeBarCodeModelBarcodeImageFormat**](../Model/.md)| Barcode output image format. Default value: png. | [optional] [default to &#39;Png&#39;] |
 | **text_location** | [**\Aspose\BarCode\Model\CodeLocation**](../Model/.md)| Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes. | [optional] |
 | **foreground_color** | **string**| Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black. | [optional] [default to &#39;Black&#39;] |
 | **background_color** | **string**| Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White. | [optional] [default to &#39;White&#39;] |
@@ -212,35 +212,35 @@ $apiInstance = new Aspose\BarCode\Api\GenerateApi(
     new GuzzleHttp\Client(),
     $config
 );
-$barcode_type = new \Aspose\BarCode\Model\EncodeBarcodeType(); // \Aspose\BarCode\Model\EncodeBarcodeType
+$barcode_type = new \Aspose\BarCode\Model\EncodeBarcodeType(); // \Aspose\BarCode\Model\EncodeBarcodeType | See https://reference.aspose.com/barcode/net/aspose.barcode.generation/encodetypes/
 $data = 'data_example'; // string | String that represents the data to encode.
-$data_type = new \Aspose\BarCode\Model\EncodeDataType(); // \Aspose\BarCode\Model\EncodeDataType
-$image_format = new \Aspose\BarCode\Model\BarcodeImageFormat(); // \Aspose\BarCode\Model\BarcodeImageFormat
-$text_location = new \Aspose\BarCode\Model\CodeLocation(); // \Aspose\BarCode\Model\CodeLocation
+$data_type = new \Aspose\BarCode\Model\EncodeDataType(); // \Aspose\BarCode\Model\EncodeDataType | Type of data to encode. Default value: StringData.
+$image_format = new \Aspose\BarCode\Model\BarcodeImageFormat(); // \Aspose\BarCode\Model\BarcodeImageFormat | Barcode output image format. Default value: png.
+$text_location = new \Aspose\BarCode\Model\CodeLocation(); // \Aspose\BarCode\Model\CodeLocation | Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes.
 $foreground_color = 'Black'; // string | Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
 $background_color = 'White'; // string | Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
-$units = new \Aspose\BarCode\Model\GraphicsUnit(); // \Aspose\BarCode\Model\GraphicsUnit
+$units = new \Aspose\BarCode\Model\GraphicsUnit(); // \Aspose\BarCode\Model\GraphicsUnit | Common units for all measurements. Default units: pixels.
 $resolution = 3.4; // float | Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
 $image_height = 3.4; // float | Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
 $image_width = 3.4; // float | Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
 $rotation_angle = 56; // int | Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
-$qr_encode_mode = new \Aspose\BarCode\Model\QREncodeMode(); // \Aspose\BarCode\Model\QREncodeMode
-$qr_error_level = new \Aspose\BarCode\Model\QRErrorLevel(); // \Aspose\BarCode\Model\QRErrorLevel
-$qr_version = new \Aspose\BarCode\Model\QRVersion(); // \Aspose\BarCode\Model\QRVersion
-$qr_eci_encoding = new \Aspose\BarCode\Model\ECIEncodings(); // \Aspose\BarCode\Model\ECIEncodings
+$qr_encode_mode = new \Aspose\BarCode\Model\QREncodeMode(); // \Aspose\BarCode\Model\QREncodeMode | QR barcode encode mode.
+$qr_error_level = new \Aspose\BarCode\Model\QRErrorLevel(); // \Aspose\BarCode\Model\QRErrorLevel | QR barcode error correction level.
+$qr_version = new \Aspose\BarCode\Model\QRVersion(); // \Aspose\BarCode\Model\QRVersion | QR barcode version. Automatically selects the smallest version that fits the data.
+$qr_eci_encoding = new \Aspose\BarCode\Model\ECIEncodings(); // \Aspose\BarCode\Model\ECIEncodings | ECI encoding for QR barcode data.
 $qr_aspect_ratio = 3.4; // float | QR barcode aspect ratio. Values: 0 to 1.
-$micro_qr_version = new \Aspose\BarCode\Model\MicroQRVersion(); // \Aspose\BarCode\Model\MicroQRVersion
-$rect_micro_qr_version = new \Aspose\BarCode\Model\RectMicroQRVersion(); // \Aspose\BarCode\Model\RectMicroQRVersion
-$code128_encode_mode = new \Aspose\BarCode\Model\Code128EncodeMode(); // \Aspose\BarCode\Model\Code128EncodeMode
-$pdf417_encode_mode = new \Aspose\BarCode\Model\Pdf417EncodeMode(); // \Aspose\BarCode\Model\Pdf417EncodeMode
-$pdf417_error_level = new \Aspose\BarCode\Model\Pdf417ErrorLevel(); // \Aspose\BarCode\Model\Pdf417ErrorLevel
+$micro_qr_version = new \Aspose\BarCode\Model\MicroQRVersion(); // \Aspose\BarCode\Model\MicroQRVersion | MicroQR barcode version. Used when BarcodeType is MicroQR.
+$rect_micro_qr_version = new \Aspose\BarCode\Model\RectMicroQRVersion(); // \Aspose\BarCode\Model\RectMicroQRVersion | RectMicroQR barcode version. Used when BarcodeType is RectMicroQR.
+$code128_encode_mode = new \Aspose\BarCode\Model\Code128EncodeMode(); // \Aspose\BarCode\Model\Code128EncodeMode | Code128 barcode encode mode. Controls which Code 128 subset (A, B, C, or mix) is used.
+$pdf417_encode_mode = new \Aspose\BarCode\Model\Pdf417EncodeMode(); // \Aspose\BarCode\Model\Pdf417EncodeMode | PDF417 barcode encode mode.
+$pdf417_error_level = new \Aspose\BarCode\Model\Pdf417ErrorLevel(); // \Aspose\BarCode\Model\Pdf417ErrorLevel | PDF417 barcode error correction level.
 $pdf417_truncate = True; // bool | Whether to use truncated PDF417 format (removes right-side stop pattern).
 $pdf417_columns = 56; // int | Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
 $pdf417_rows = 56; // int | Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
 $pdf417_aspect_ratio = 3.4; // float | PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
-$pdf417_eci_encoding = new \Aspose\BarCode\Model\ECIEncodings(); // \Aspose\BarCode\Model\ECIEncodings
+$pdf417_eci_encoding = new \Aspose\BarCode\Model\ECIEncodings(); // \Aspose\BarCode\Model\ECIEncodings | ECI encoding for PDF417 barcode data.
 $pdf417_is_reader_initialization = True; // bool | Whether the barcode is used for reader initialization (programming).
-$pdf417_macro_characters = new \Aspose\BarCode\Model\MacroCharacter(); // \Aspose\BarCode\Model\MacroCharacter
+$pdf417_macro_characters = new \Aspose\BarCode\Model\MacroCharacter(); // \Aspose\BarCode\Model\MacroCharacter | Macro character to prepend (structured append).
 $pdf417_is_linked = True; // bool | Whether to use linked mode (for MicroPdf417).
 $pdf417_is_code128_emulation = True; // bool | Whether to use Code128 emulation for MicroPdf417.
 
@@ -256,35 +256,35 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **barcode_type** | [**\Aspose\BarCode\Model\EncodeBarcodeType**](../Model/EncodeBarcodeType.md)|  | |
+| **barcode_type** | [**\Aspose\BarCode\Model\EncodeBarcodeType**](../Model/EncodeBarcodeType.md)| See https://reference.aspose.com/barcode/net/aspose.barcode.generation/encodetypes/ | |
 | **data** | **string**| String that represents the data to encode. | |
-| **data_type** | [**\Aspose\BarCode\Model\EncodeDataType**](../Model/EncodeDataType.md)|  | [optional] |
-| **image_format** | [**\Aspose\BarCode\Model\BarcodeImageFormat**](../Model/BarcodeImageFormat.md)|  | [optional] |
-| **text_location** | [**\Aspose\BarCode\Model\CodeLocation**](../Model/CodeLocation.md)|  | [optional] |
+| **data_type** | [**\Aspose\BarCode\Model\EncodeDataType**](../Model/EncodeDataType.md)| Type of data to encode. Default value: StringData. | [optional] [default to &#39;StringData&#39;] |
+| **image_format** | [**\Aspose\BarCode\Model\BarcodeImageFormat**](../Model/BarcodeImageFormat.md)| Barcode output image format. Default value: png. | [optional] [default to &#39;Png&#39;] |
+| **text_location** | [**\Aspose\BarCode\Model\CodeLocation**](../Model/CodeLocation.md)| Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes. | [optional] |
 | **foreground_color** | **string**| Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black. | [optional] [default to &#39;Black&#39;] |
 | **background_color** | **string**| Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White. | [optional] [default to &#39;White&#39;] |
-| **units** | [**\Aspose\BarCode\Model\GraphicsUnit**](../Model/GraphicsUnit.md)|  | [optional] |
+| **units** | [**\Aspose\BarCode\Model\GraphicsUnit**](../Model/GraphicsUnit.md)| Common units for all measurements. Default units: pixels. | [optional] |
 | **resolution** | **float**| Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot. | [optional] |
 | **image_height** | **float**| Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot. | [optional] |
 | **image_width** | **float**| Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot. | [optional] |
 | **rotation_angle** | **int**| Barcode image rotation angle, measured in degrees. For example, RotationAngle &#x3D; 0 or RotationAngle &#x3D; 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0. | [optional] |
-| **qr_encode_mode** | [**\Aspose\BarCode\Model\QREncodeMode**](../Model/QREncodeMode.md)|  | [optional] |
-| **qr_error_level** | [**\Aspose\BarCode\Model\QRErrorLevel**](../Model/QRErrorLevel.md)|  | [optional] |
-| **qr_version** | [**\Aspose\BarCode\Model\QRVersion**](../Model/QRVersion.md)|  | [optional] |
-| **qr_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](../Model/ECIEncodings.md)|  | [optional] |
+| **qr_encode_mode** | [**\Aspose\BarCode\Model\QREncodeMode**](../Model/QREncodeMode.md)| QR barcode encode mode. | [optional] |
+| **qr_error_level** | [**\Aspose\BarCode\Model\QRErrorLevel**](../Model/QRErrorLevel.md)| QR barcode error correction level. | [optional] |
+| **qr_version** | [**\Aspose\BarCode\Model\QRVersion**](../Model/QRVersion.md)| QR barcode version. Automatically selects the smallest version that fits the data. | [optional] |
+| **qr_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](../Model/ECIEncodings.md)| ECI encoding for QR barcode data. | [optional] |
 | **qr_aspect_ratio** | **float**| QR barcode aspect ratio. Values: 0 to 1. | [optional] |
-| **micro_qr_version** | [**\Aspose\BarCode\Model\MicroQRVersion**](../Model/MicroQRVersion.md)|  | [optional] |
-| **rect_micro_qr_version** | [**\Aspose\BarCode\Model\RectMicroQRVersion**](../Model/RectMicroQRVersion.md)|  | [optional] |
-| **code128_encode_mode** | [**\Aspose\BarCode\Model\Code128EncodeMode**](../Model/Code128EncodeMode.md)|  | [optional] |
-| **pdf417_encode_mode** | [**\Aspose\BarCode\Model\Pdf417EncodeMode**](../Model/Pdf417EncodeMode.md)|  | [optional] |
-| **pdf417_error_level** | [**\Aspose\BarCode\Model\Pdf417ErrorLevel**](../Model/Pdf417ErrorLevel.md)|  | [optional] |
+| **micro_qr_version** | [**\Aspose\BarCode\Model\MicroQRVersion**](../Model/MicroQRVersion.md)| MicroQR barcode version. Used when BarcodeType is MicroQR. | [optional] |
+| **rect_micro_qr_version** | [**\Aspose\BarCode\Model\RectMicroQRVersion**](../Model/RectMicroQRVersion.md)| RectMicroQR barcode version. Used when BarcodeType is RectMicroQR. | [optional] |
+| **code128_encode_mode** | [**\Aspose\BarCode\Model\Code128EncodeMode**](../Model/Code128EncodeMode.md)| Code128 barcode encode mode. Controls which Code 128 subset (A, B, C, or mix) is used. | [optional] |
+| **pdf417_encode_mode** | [**\Aspose\BarCode\Model\Pdf417EncodeMode**](../Model/Pdf417EncodeMode.md)| PDF417 barcode encode mode. | [optional] |
+| **pdf417_error_level** | [**\Aspose\BarCode\Model\Pdf417ErrorLevel**](../Model/Pdf417ErrorLevel.md)| PDF417 barcode error correction level. | [optional] |
 | **pdf417_truncate** | **bool**| Whether to use truncated PDF417 format (removes right-side stop pattern). | [optional] |
 | **pdf417_columns** | **int**| Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto. | [optional] |
 | **pdf417_rows** | **int**| Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic. | [optional] |
 | **pdf417_aspect_ratio** | **float**| PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417. | [optional] |
-| **pdf417_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](../Model/ECIEncodings.md)|  | [optional] |
+| **pdf417_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](../Model/ECIEncodings.md)| ECI encoding for PDF417 barcode data. | [optional] |
 | **pdf417_is_reader_initialization** | **bool**| Whether the barcode is used for reader initialization (programming). | [optional] |
-| **pdf417_macro_characters** | [**\Aspose\BarCode\Model\MacroCharacter**](../Model/MacroCharacter.md)|  | [optional] |
+| **pdf417_macro_characters** | [**\Aspose\BarCode\Model\MacroCharacter**](../Model/MacroCharacter.md)| Macro character to prepend (structured append). | [optional] |
 | **pdf417_is_linked** | **bool**| Whether to use linked mode (for MicroPdf417). | [optional] |
 | **pdf417_is_code128_emulation** | **bool**| Whether to use Code128 emulation for MicroPdf417. | [optional] |
 

--- a/docs/Api/RecognizeApi.md
+++ b/docs/Api/RecognizeApi.md
@@ -6,9 +6,9 @@ All URIs are relative to https://api.aspose.cloud/v4.0, except if the operation 
 
 | Method | HTTP request | Description |
 | ------------- | ------------- | ------------- |
-| [**recognize()**](RecognizeApi.md#recognize) | **GET** /barcode/recognize | Recognize barcode from file on server in the Internet using GET requests with parameter in query string. For recognizing files from your hard drive use &#x60;recognize-body&#x60; or &#x60;recognize-multipart&#x60; endpoints instead. |
-| [**recognizeBase64()**](RecognizeApi.md#recognizeBase64) | **POST** /barcode/recognize-body | Recognize barcode from file in request body using POST requests with parameters in body in json or xml format. |
-| [**recognizeMultipart()**](RecognizeApi.md#recognizeMultipart) | **POST** /barcode/recognize-multipart | Recognize barcode from file in request body using POST requests with parameters in multipart form. |
+| [**recognize()**](RecognizeApi.md#recognize) | **GET** /barcode/recognize | Recognize a barcode from a file on an Internet server using a GET request with a query string parameter. For recognizing files from your hard drive, use &#x60;recognize-body&#x60; or &#x60;recognize-multipart&#x60; endpoints instead. |
+| [**recognizeBase64()**](RecognizeApi.md#recognizeBase64) | **POST** /barcode/recognize-body | Recognize a barcode from a file in the request body using a POST request with JSON or XML body parameters. |
+| [**recognizeMultipart()**](RecognizeApi.md#recognizeMultipart) | **POST** /barcode/recognize-multipart | Recognize a barcode from a file in the request body using a POST request with multipart form parameters. |
 
 
 ## `recognize()`
@@ -17,7 +17,7 @@ All URIs are relative to https://api.aspose.cloud/v4.0, except if the operation 
 recognize($barcode_type, $file_url, $recognition_mode, $recognition_image_kind): \Aspose\BarCode\Model\BarcodeResponseList
 ```
 
-Recognize barcode from file on server in the Internet using GET requests with parameter in query string. For recognizing files from your hard drive use `recognize-body` or `recognize-multipart` endpoints instead.
+Recognize a barcode from a file on an Internet server using a GET request with a query string parameter. For recognizing files from your hard drive, use `recognize-body` or `recognize-multipart` endpoints instead.
 
 ### Example
 
@@ -36,10 +36,10 @@ $apiInstance = new Aspose\BarCode\Api\RecognizeApi(
     new GuzzleHttp\Client(),
     $config
 );
-$barcode_type = new \Aspose\BarCode\Model\DecodeBarcodeType(); // \Aspose\BarCode\Model\DecodeBarcodeType | Type of barcode to recognize
-$file_url = 'file_url_example'; // string | Url to barcode image
-$recognition_mode = new \Aspose\BarCode\Model\RecognitionMode(); // \Aspose\BarCode\Model\RecognitionMode | Recognition mode
-$recognition_image_kind = new \Aspose\BarCode\Model\RecognitionImageKind(); // \Aspose\BarCode\Model\RecognitionImageKind | Image kind for recognition
+$barcode_type = new \Aspose\BarCode\Model\DecodeBarcodeType(); // \Aspose\BarCode\Model\DecodeBarcodeType | Type of barcode to recognize.
+$file_url = 'file_url_example'; // string | URL to the barcode image.
+$recognition_mode = new \Aspose\BarCode\Model\RecognitionMode(); // \Aspose\BarCode\Model\RecognitionMode | Recognition mode.
+$recognition_image_kind = new \Aspose\BarCode\Model\RecognitionImageKind(); // \Aspose\BarCode\Model\RecognitionImageKind | Image kind for recognition.
 
 try {
     $result = $apiInstance->recognize($barcode_type, $file_url, $recognition_mode, $recognition_image_kind);
@@ -53,10 +53,10 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **barcode_type** | [**\Aspose\BarCode\Model\DecodeBarcodeType**](../Model/.md)| Type of barcode to recognize | |
-| **file_url** | **string**| Url to barcode image | |
-| **recognition_mode** | [**\Aspose\BarCode\Model\RecognitionMode**](../Model/.md)| Recognition mode | [optional] |
-| **recognition_image_kind** | [**\Aspose\BarCode\Model\RecognitionImageKind**](../Model/.md)| Image kind for recognition | [optional] |
+| **barcode_type** | [**\Aspose\BarCode\Model\DecodeBarcodeType**](../Model/.md)| Type of barcode to recognize. | |
+| **file_url** | **string**| URL to the barcode image. | |
+| **recognition_mode** | [**\Aspose\BarCode\Model\RecognitionMode**](../Model/.md)| Recognition mode. | [optional] |
+| **recognition_image_kind** | [**\Aspose\BarCode\Model\RecognitionImageKind**](../Model/.md)| Image kind for recognition. | [optional] |
 
 ### Return type
 
@@ -81,7 +81,7 @@ try {
 recognizeBase64($recognize_base64_request): \Aspose\BarCode\Model\BarcodeResponseList
 ```
 
-Recognize barcode from file in request body using POST requests with parameters in body in json or xml format.
+Recognize a barcode from a file in the request body using a POST request with JSON or XML body parameters.
 
 ### Example
 
@@ -100,7 +100,7 @@ $apiInstance = new Aspose\BarCode\Api\RecognizeApi(
     new GuzzleHttp\Client(),
     $config
 );
-$recognize_base64_request = new \Aspose\BarCode\Model\RecognizeBase64Request(); // \Aspose\BarCode\Model\RecognizeBase64Request | Barcode recognition request
+$recognize_base64_request = new \Aspose\BarCode\Model\RecognizeBase64Request(); // \Aspose\BarCode\Model\RecognizeBase64Request | Barcode recognition request.
 
 try {
     $result = $apiInstance->recognizeBase64($recognize_base64_request);
@@ -114,7 +114,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **recognize_base64_request** | [**\Aspose\BarCode\Model\RecognizeBase64Request**](../Model/RecognizeBase64Request.md)| Barcode recognition request | |
+| **recognize_base64_request** | [**\Aspose\BarCode\Model\RecognizeBase64Request**](../Model/RecognizeBase64Request.md)| Barcode recognition request. | |
 
 ### Return type
 
@@ -139,7 +139,7 @@ try {
 recognizeMultipart($barcode_type, $file, $recognition_mode, $recognition_image_kind): \Aspose\BarCode\Model\BarcodeResponseList
 ```
 
-Recognize barcode from file in request body using POST requests with parameters in multipart form.
+Recognize a barcode from a file in the request body using a POST request with multipart form parameters.
 
 ### Example
 
@@ -159,7 +159,7 @@ $apiInstance = new Aspose\BarCode\Api\RecognizeApi(
     $config
 );
 $barcode_type = new \Aspose\BarCode\Model\DecodeBarcodeType(); // \Aspose\BarCode\Model\DecodeBarcodeType
-$file = '/path/to/file.txt'; // \SplFileObject | Barcode image file
+$file = '/path/to/file.txt'; // \SplFileObject | Barcode image file.
 $recognition_mode = new \Aspose\BarCode\Model\RecognitionMode(); // \Aspose\BarCode\Model\RecognitionMode
 $recognition_image_kind = new \Aspose\BarCode\Model\RecognitionImageKind(); // \Aspose\BarCode\Model\RecognitionImageKind
 
@@ -176,7 +176,7 @@ try {
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **barcode_type** | [**\Aspose\BarCode\Model\DecodeBarcodeType**](../Model/DecodeBarcodeType.md)|  | |
-| **file** | **\SplFileObject****\SplFileObject**| Barcode image file | |
+| **file** | **\SplFileObject****\SplFileObject**| Barcode image file. | |
 | **recognition_mode** | [**\Aspose\BarCode\Model\RecognitionMode**](../Model/RecognitionMode.md)|  | [optional] |
 | **recognition_image_kind** | [**\Aspose\BarCode\Model\RecognitionImageKind**](../Model/RecognitionImageKind.md)|  | [optional] |
 

--- a/docs/Api/RecognizeApi.md
+++ b/docs/Api/RecognizeApi.md
@@ -36,10 +36,10 @@ $apiInstance = new Aspose\BarCode\Api\RecognizeApi(
     new GuzzleHttp\Client(),
     $config
 );
-$barcode_type = new \Aspose\BarCode\Model\DecodeBarcodeType(); // \Aspose\BarCode\Model\DecodeBarcodeType | Type of barcode to recognize.
+$barcode_type = new \Aspose\BarCode\Model\\AsposeBarCodeModelDecodeBarcodeType(); // \AsposeBarCodeModelDecodeBarcodeType | Type of barcode to recognize.
 $file_url = 'file_url_example'; // string | URL to the barcode image.
-$recognition_mode = new \Aspose\BarCode\Model\RecognitionMode(); // \Aspose\BarCode\Model\RecognitionMode | Recognition mode.
-$recognition_image_kind = new \Aspose\BarCode\Model\RecognitionImageKind(); // \Aspose\BarCode\Model\RecognitionImageKind | Image kind for recognition.
+$recognition_mode = new \Aspose\BarCode\Model\\AsposeBarCodeModelRecognitionMode(); // \AsposeBarCodeModelRecognitionMode | Recognition mode.
+$recognition_image_kind = new \Aspose\BarCode\Model\\AsposeBarCodeModelRecognitionImageKind(); // \AsposeBarCodeModelRecognitionImageKind | Image kind for recognition.
 
 try {
     $result = $apiInstance->recognize($barcode_type, $file_url, $recognition_mode, $recognition_image_kind);
@@ -53,10 +53,10 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **barcode_type** | [**\Aspose\BarCode\Model\DecodeBarcodeType**](../Model/.md)| Type of barcode to recognize. | |
+| **barcode_type** | [**\AsposeBarCodeModelDecodeBarcodeType**](../Model/.md)| Type of barcode to recognize. | |
 | **file_url** | **string**| URL to the barcode image. | |
-| **recognition_mode** | [**\Aspose\BarCode\Model\RecognitionMode**](../Model/.md)| Recognition mode. | [optional] |
-| **recognition_image_kind** | [**\Aspose\BarCode\Model\RecognitionImageKind**](../Model/.md)| Image kind for recognition. | [optional] |
+| **recognition_mode** | [**\AsposeBarCodeModelRecognitionMode**](../Model/.md)| Recognition mode. | [optional] |
+| **recognition_image_kind** | [**\AsposeBarCodeModelRecognitionImageKind**](../Model/.md)| Image kind for recognition. | [optional] |
 
 ### Return type
 
@@ -158,10 +158,10 @@ $apiInstance = new Aspose\BarCode\Api\RecognizeApi(
     new GuzzleHttp\Client(),
     $config
 );
-$barcode_type = new \Aspose\BarCode\Model\DecodeBarcodeType(); // \Aspose\BarCode\Model\DecodeBarcodeType
+$barcode_type = new \Aspose\BarCode\Model\DecodeBarcodeType(); // \Aspose\BarCode\Model\DecodeBarcodeType | See https://reference.aspose.com/barcode/net/aspose.barcode.barcoderecognition/decodetype/
 $file = '/path/to/file.txt'; // \SplFileObject | Barcode image file.
-$recognition_mode = new \Aspose\BarCode\Model\RecognitionMode(); // \Aspose\BarCode\Model\RecognitionMode
-$recognition_image_kind = new \Aspose\BarCode\Model\RecognitionImageKind(); // \Aspose\BarCode\Model\RecognitionImageKind
+$recognition_mode = new \Aspose\BarCode\Model\RecognitionMode(); // \Aspose\BarCode\Model\RecognitionMode | Recognition mode.
+$recognition_image_kind = new \Aspose\BarCode\Model\RecognitionImageKind(); // \Aspose\BarCode\Model\RecognitionImageKind | Image kind for recognition.
 
 try {
     $result = $apiInstance->recognizeMultipart($barcode_type, $file, $recognition_mode, $recognition_image_kind);
@@ -175,10 +175,10 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **barcode_type** | [**\Aspose\BarCode\Model\DecodeBarcodeType**](../Model/DecodeBarcodeType.md)|  | |
+| **barcode_type** | [**\Aspose\BarCode\Model\DecodeBarcodeType**](../Model/DecodeBarcodeType.md)| See https://reference.aspose.com/barcode/net/aspose.barcode.barcoderecognition/decodetype/ | |
 | **file** | **\SplFileObject****\SplFileObject**| Barcode image file. | |
-| **recognition_mode** | [**\Aspose\BarCode\Model\RecognitionMode**](../Model/RecognitionMode.md)|  | [optional] |
-| **recognition_image_kind** | [**\Aspose\BarCode\Model\RecognitionImageKind**](../Model/RecognitionImageKind.md)|  | [optional] |
+| **recognition_mode** | [**\Aspose\BarCode\Model\RecognitionMode**](../Model/RecognitionMode.md)| Recognition mode. | [optional] |
+| **recognition_image_kind** | [**\Aspose\BarCode\Model\RecognitionImageKind**](../Model/RecognitionImageKind.md)| Image kind for recognition. | [optional] |
 
 ### Return type
 

--- a/docs/Api/ScanApi.md
+++ b/docs/Api/ScanApi.md
@@ -6,9 +6,9 @@ All URIs are relative to https://api.aspose.cloud/v4.0, except if the operation 
 
 | Method | HTTP request | Description |
 | ------------- | ------------- | ------------- |
-| [**scan()**](ScanApi.md#scan) | **GET** /barcode/scan | Scan barcode from file on server in the Internet using GET requests with parameter in query string. For scaning files from your hard drive use &#x60;scan-body&#x60; or &#x60;scan-multipart&#x60; endpoints instead. |
-| [**scanBase64()**](ScanApi.md#scanBase64) | **POST** /barcode/scan-body | Scan barcode from file in request body using POST requests with parameter in body in json or xml format. |
-| [**scanMultipart()**](ScanApi.md#scanMultipart) | **POST** /barcode/scan-multipart | Scan barcode from file in request body using POST requests with parameter in multipart form. |
+| [**scan()**](ScanApi.md#scan) | **GET** /barcode/scan | Scan a barcode from a file on an Internet server using a GET request with a query string parameter. For scanning files from your hard drive, use &#x60;scan-body&#x60; or &#x60;scan-multipart&#x60; endpoints instead. |
+| [**scanBase64()**](ScanApi.md#scanBase64) | **POST** /barcode/scan-body | Scan a barcode from a file in the request body using a POST request with a JSON or XML body parameter. |
+| [**scanMultipart()**](ScanApi.md#scanMultipart) | **POST** /barcode/scan-multipart | Scan a barcode from a file in the request body using a POST request with a multipart form parameter. |
 
 
 ## `scan()`
@@ -17,7 +17,7 @@ All URIs are relative to https://api.aspose.cloud/v4.0, except if the operation 
 scan($file_url): \Aspose\BarCode\Model\BarcodeResponseList
 ```
 
-Scan barcode from file on server in the Internet using GET requests with parameter in query string. For scaning files from your hard drive use `scan-body` or `scan-multipart` endpoints instead.
+Scan a barcode from a file on an Internet server using a GET request with a query string parameter. For scanning files from your hard drive, use `scan-body` or `scan-multipart` endpoints instead.
 
 ### Example
 
@@ -36,7 +36,7 @@ $apiInstance = new Aspose\BarCode\Api\ScanApi(
     new GuzzleHttp\Client(),
     $config
 );
-$file_url = 'file_url_example'; // string | Url to barcode image
+$file_url = 'file_url_example'; // string | URL to the barcode image.
 
 try {
     $result = $apiInstance->scan($file_url);
@@ -50,7 +50,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **file_url** | **string**| Url to barcode image | |
+| **file_url** | **string**| URL to the barcode image. | |
 
 ### Return type
 
@@ -75,7 +75,7 @@ try {
 scanBase64($scan_base64_request): \Aspose\BarCode\Model\BarcodeResponseList
 ```
 
-Scan barcode from file in request body using POST requests with parameter in body in json or xml format.
+Scan a barcode from a file in the request body using a POST request with a JSON or XML body parameter.
 
 ### Example
 
@@ -94,7 +94,7 @@ $apiInstance = new Aspose\BarCode\Api\ScanApi(
     new GuzzleHttp\Client(),
     $config
 );
-$scan_base64_request = new \Aspose\BarCode\Model\ScanBase64Request(); // \Aspose\BarCode\Model\ScanBase64Request | Barcode scan request
+$scan_base64_request = new \Aspose\BarCode\Model\ScanBase64Request(); // \Aspose\BarCode\Model\ScanBase64Request | Barcode scan request.
 
 try {
     $result = $apiInstance->scanBase64($scan_base64_request);
@@ -108,7 +108,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **scan_base64_request** | [**\Aspose\BarCode\Model\ScanBase64Request**](../Model/ScanBase64Request.md)| Barcode scan request | |
+| **scan_base64_request** | [**\Aspose\BarCode\Model\ScanBase64Request**](../Model/ScanBase64Request.md)| Barcode scan request. | |
 
 ### Return type
 
@@ -133,7 +133,7 @@ try {
 scanMultipart($file): \Aspose\BarCode\Model\BarcodeResponseList
 ```
 
-Scan barcode from file in request body using POST requests with parameter in multipart form.
+Scan a barcode from a file in the request body using a POST request with a multipart form parameter.
 
 ### Example
 
@@ -152,7 +152,7 @@ $apiInstance = new Aspose\BarCode\Api\ScanApi(
     new GuzzleHttp\Client(),
     $config
 );
-$file = '/path/to/file.txt'; // \SplFileObject | Barcode image file
+$file = '/path/to/file.txt'; // \SplFileObject | Barcode image file.
 
 try {
     $result = $apiInstance->scanMultipart($file);
@@ -166,7 +166,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **file** | **\SplFileObject****\SplFileObject**| Barcode image file | |
+| **file** | **\SplFileObject****\SplFileObject**| Barcode image file. | |
 
 ### Return type
 

--- a/docs/Model/ApiError.md
+++ b/docs/Model/ApiError.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **message** | **string** | Gets or sets error message. | 
 **description** | **string** | Gets or sets error description. | [optional] 
 **date_time** | **\DateTime** | Gets or sets server datetime. | [optional] 
-**inner_error** | [**\Aspose\BarCode\Model\ApiError**](ApiError.md) |  | [optional] 
+**inner_error** | [**\Aspose\BarCode\Model\ApiError**](ApiError.md) | Gets or sets inner error. | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/ApiErrorResponse.md
+++ b/docs/Model/ApiErrorResponse.md
@@ -6,7 +6,7 @@ ApiError Response
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
 **request_id** | **string** | Gets or sets request Id. | 
-**error** | [**\Aspose\BarCode\Model\ApiError**](ApiError.md) |  | 
+**error** | [**\Aspose\BarCode\Model\ApiError**](ApiError.md) | Gets or sets error. | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/BarcodeImageParams.md
+++ b/docs/Model/BarcodeImageParams.md
@@ -5,11 +5,11 @@ Optional barcode image parameters.
 ## Properties
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
-**image_format** | [**\Aspose\BarCode\Model\BarcodeImageFormat**](BarcodeImageFormat.md) |  | [optional] 
-**text_location** | [**\Aspose\BarCode\Model\CodeLocation**](CodeLocation.md) |  | [optional] 
+**image_format** | [**\Aspose\BarCode\Model\BarcodeImageFormat**](BarcodeImageFormat.md) | Barcode output image format. Default value: png. | [optional] [default to BarcodeImageFormat::PNG]
+**text_location** | [**\Aspose\BarCode\Model\CodeLocation**](CodeLocation.md) | Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes. | [optional] 
 **foreground_color** | **string** | Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black. | [optional] [default to 'Black']
 **background_color** | **string** | Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White. | [optional] [default to 'White']
-**units** | [**\Aspose\BarCode\Model\GraphicsUnit**](GraphicsUnit.md) |  | [optional] 
+**units** | [**\Aspose\BarCode\Model\GraphicsUnit**](GraphicsUnit.md) | Common units for all measurements. Default units: pixels. | [optional] 
 **resolution** | **float** | Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot. | [optional] 
 **image_height** | **float** | Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot. | [optional] 
 **image_width** | **float** | Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot. | [optional] 

--- a/docs/Model/BarcodeImageParams.md
+++ b/docs/Model/BarcodeImageParams.md
@@ -1,19 +1,19 @@
 # BarcodeImageParams
 
-Barcode image optional parameters
+Optional barcode image parameters.
 
 ## Properties
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
 **image_format** | [**\Aspose\BarCode\Model\BarcodeImageFormat**](BarcodeImageFormat.md) |  | [optional] 
 **text_location** | [**\Aspose\BarCode\Model\CodeLocation**](CodeLocation.md) |  | [optional] 
-**foreground_color** | **string** | Specify the displaying bars and content Color. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: Black. | [optional] [default to 'Black']
-**background_color** | **string** | Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: White. | [optional] [default to 'White']
+**foreground_color** | **string** | Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black. | [optional] [default to 'Black']
+**background_color** | **string** | Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White. | [optional] [default to 'White']
 **units** | [**\Aspose\BarCode\Model\GraphicsUnit**](GraphicsUnit.md) |  | [optional] 
-**resolution** | **float** | Resolution of the BarCode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is dot. | [optional] 
-**image_height** | **float** | Height of the barcode image in given units. Default units: pixel. Decimal separator is dot. | [optional] 
-**image_width** | **float** | Width of the barcode image in given units. Default units: pixel. Decimal separator is dot. | [optional] 
-**rotation_angle** | **int** | BarCode image rotation angle, measured in degree, e.g. RotationAngle &#x3D; 0 or RotationAngle &#x3D; 360 means no rotation. If RotationAngle NOT equal to 90, 180, 270 or 0, it may increase the difficulty for the scanner to read the image. Default value: 0. | [optional] 
+**resolution** | **float** | Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot. | [optional] 
+**image_height** | **float** | Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot. | [optional] 
+**image_width** | **float** | Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot. | [optional] 
+**rotation_angle** | **int** | Barcode image rotation angle, measured in degrees. For example, RotationAngle &#x3D; 0 or RotationAngle &#x3D; 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0. | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/BarcodeResponse.md
+++ b/docs/Model/BarcodeResponse.md
@@ -1,14 +1,14 @@
 # BarcodeResponse
 
-Represents information about barcode.
+Represents information about a barcode.
 
 ## Properties
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
 **barcode_value** | **string** | Barcode data. | [optional] 
 **type** | **string** | Type of the barcode. | [optional] 
-**region** | [**\Aspose\BarCode\Model\RegionPoint[]**](RegionPoint.md) | Region with barcode. | [optional] 
-**checksum** | **string** | Checksum of barcode. | [optional] 
+**region** | [**\Aspose\BarCode\Model\RegionPoint[]**](RegionPoint.md) | Region with the barcode. | [optional] 
+**checksum** | **string** | Checksum of the barcode. | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/BarcodeResponseList.md
+++ b/docs/Model/BarcodeResponseList.md
@@ -1,11 +1,11 @@
 # BarcodeResponseList
 
-Represents information about barcode list.
+Represents information about a barcode list.
 
 ## Properties
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
-**barcodes** | [**\Aspose\BarCode\Model\BarcodeResponse[]**](BarcodeResponse.md) | List of barcodes which are present in image. | 
+**barcodes** | [**\Aspose\BarCode\Model\BarcodeResponse[]**](BarcodeResponse.md) | List of barcodes that are present in the image. | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/Code128EncodeMode.md
+++ b/docs/Model/Code128EncodeMode.md
@@ -1,0 +1,16 @@
+# Code128EncodeMode
+
+Code128 barcode encode mode. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/code128encodemode/
+## Allowable values
+
+* **AUTO**
+* CODE_A
+* CODE_B
+* CODE_AB
+* CODE_C
+* CODE_AC
+* CODE_BC
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/Code128Params.md
+++ b/docs/Model/Code128Params.md
@@ -1,0 +1,12 @@
+# Code128Params
+
+Optional Code128 barcode generation parameters.
+
+## Properties
+Name | Type | Description | Notes
+---- | ---- | ----------- | -----
+**code128_encode_mode** | [**\Aspose\BarCode\Model\Code128EncodeMode**](Code128EncodeMode.md) |  | [optional] 
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/Code128Params.md
+++ b/docs/Model/Code128Params.md
@@ -5,7 +5,7 @@ Optional Code128 barcode generation parameters.
 ## Properties
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
-**code128_encode_mode** | [**\Aspose\BarCode\Model\Code128EncodeMode**](Code128EncodeMode.md) |  | [optional] 
+**code128_encode_mode** | [**\Aspose\BarCode\Model\Code128EncodeMode**](Code128EncodeMode.md) | Code128 barcode encode mode. Controls which Code 128 subset (A, B, C, or mix) is used. | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/DecodeBarcodeType.md
+++ b/docs/Model/DecodeBarcodeType.md
@@ -1,6 +1,6 @@
 # DecodeBarcodeType
 
-See Aspose.BarCode.BarCodeRecognition.DecodeType
+See https://reference.aspose.com/barcode/net/aspose.barcode.barcoderecognition/decodetype/
 ## Allowable values
 
 * **MOST_COMMONLY_USED**

--- a/docs/Model/ECIEncodings.md
+++ b/docs/Model/ECIEncodings.md
@@ -1,0 +1,43 @@
+# ECIEncodings
+
+ECI encoding identifiers. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/eciencodings/
+## Allowable values
+
+* **NONE**
+* ISO_8859_1
+* ISO_8859_2
+* ISO_8859_3
+* ISO_8859_4
+* ISO_8859_5
+* ISO_8859_6
+* ISO_8859_7
+* ISO_8859_8
+* ISO_8859_9
+* ISO_8859_10
+* ISO_8859_11
+* ISO_8859_13
+* ISO_8859_14
+* ISO_8859_15
+* ISO_8859_16
+* SHIFT_JIS
+* WIN1250
+* WIN1251
+* WIN1252
+* WIN1256
+* UTF16_BE
+* UTF8
+* US_ASCII
+* BIG5
+* GB2312
+* EUC_KR
+* GBK
+* GB18030
+* UTF16_LE
+* UTF32_BE
+* UTF32_LE
+* INVARIANT
+* BINARY
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/EncodeBarcodeType.md
+++ b/docs/Model/EncodeBarcodeType.md
@@ -1,6 +1,6 @@
 # EncodeBarcodeType
 
-See Aspose.BarCode.Generation.EncodeTypes
+See https://reference.aspose.com/barcode/net/aspose.barcode.generation/encodetypes/
 ## Allowable values
 
 * **QR**

--- a/docs/Model/EncodeData.md
+++ b/docs/Model/EncodeData.md
@@ -5,7 +5,7 @@ Data to encode in a barcode.
 ## Properties
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
-**data_type** | [**\Aspose\BarCode\Model\EncodeDataType**](EncodeDataType.md) |  | [optional] 
+**data_type** | [**\Aspose\BarCode\Model\EncodeDataType**](EncodeDataType.md) | Type of data to encode. Default value: StringData. | [optional] [default to EncodeDataType::STRING_DATA]
 **data** | **string** | String that represents the data to encode. | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)

--- a/docs/Model/EncodeData.md
+++ b/docs/Model/EncodeData.md
@@ -1,12 +1,12 @@
 # EncodeData
 
-Data to encode in barcode
+Data to encode in a barcode.
 
 ## Properties
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
 **data_type** | [**\Aspose\BarCode\Model\EncodeDataType**](EncodeDataType.md) |  | [optional] 
-**data** | **string** | String represents data to encode | 
+**data** | **string** | String that represents the data to encode. | 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/EncodeDataType.md
+++ b/docs/Model/EncodeDataType.md
@@ -1,6 +1,6 @@
 # EncodeDataType
 
-Types of data can be encoded to barcode
+Types of data that can be encoded into a barcode.
 ## Allowable values
 
 * **STRING_DATA**

--- a/docs/Model/GenerateParams.md
+++ b/docs/Model/GenerateParams.md
@@ -5,12 +5,12 @@ Barcode generation parameters.
 ## Properties
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
-**barcode_type** | [**\Aspose\BarCode\Model\EncodeBarcodeType**](EncodeBarcodeType.md) |  | 
-**encode_data** | [**\Aspose\BarCode\Model\EncodeData**](EncodeData.md) |  | 
-**barcode_image_params** | [**\Aspose\BarCode\Model\BarcodeImageParams**](BarcodeImageParams.md) |  | [optional] 
-**qr_params** | [**\Aspose\BarCode\Model\QrParams**](QrParams.md) |  | [optional] 
-**code128_params** | [**\Aspose\BarCode\Model\Code128Params**](Code128Params.md) |  | [optional] 
-**pdf417_params** | [**\Aspose\BarCode\Model\Pdf417Params**](Pdf417Params.md) |  | [optional] 
+**barcode_type** | [**\Aspose\BarCode\Model\EncodeBarcodeType**](EncodeBarcodeType.md) | Barcode type. | 
+**encode_data** | [**\Aspose\BarCode\Model\EncodeData**](EncodeData.md) | Data to encode into a barcode. | 
+**barcode_image_params** | [**\Aspose\BarCode\Model\BarcodeImageParams**](BarcodeImageParams.md) | Optional barcode image parameters. | [optional] 
+**qr_params** | [**\Aspose\BarCode\Model\QrParams**](QrParams.md) | Optional QR barcode generation parameters. | [optional] 
+**code128_params** | [**\Aspose\BarCode\Model\Code128Params**](Code128Params.md) | Optional Code128 barcode generation parameters. | [optional] 
+**pdf417_params** | [**\Aspose\BarCode\Model\Pdf417Params**](Pdf417Params.md) | Optional PDF417 barcode generation parameters. | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GenerateParams.md
+++ b/docs/Model/GenerateParams.md
@@ -1,6 +1,6 @@
 # GenerateParams
 
-Barcode generation parameters
+Barcode generation parameters.
 
 ## Properties
 Name | Type | Description | Notes
@@ -8,6 +8,9 @@ Name | Type | Description | Notes
 **barcode_type** | [**\Aspose\BarCode\Model\EncodeBarcodeType**](EncodeBarcodeType.md) |  | 
 **encode_data** | [**\Aspose\BarCode\Model\EncodeData**](EncodeData.md) |  | 
 **barcode_image_params** | [**\Aspose\BarCode\Model\BarcodeImageParams**](BarcodeImageParams.md) |  | [optional] 
+**qr_params** | [**\Aspose\BarCode\Model\QrParams**](QrParams.md) |  | [optional] 
+**code128_params** | [**\Aspose\BarCode\Model\Code128Params**](Code128Params.md) |  | [optional] 
+**pdf417_params** | [**\Aspose\BarCode\Model\Pdf417Params**](Pdf417Params.md) |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/GraphicsUnit.md
+++ b/docs/Model/GraphicsUnit.md
@@ -1,6 +1,6 @@
 # GraphicsUnit
 
-Subset of Aspose.Drawing.GraphicsUnit.
+Subset of https://reference.aspose.com/drawing/net/system.drawing/graphicsunit/
 ## Allowable values
 
 * **PIXEL**

--- a/docs/Model/MacroCharacter.md
+++ b/docs/Model/MacroCharacter.md
@@ -1,0 +1,12 @@
+# MacroCharacter
+
+PDF417 macro character mode. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/macrocharacter/
+## Allowable values
+
+* **NONE**
+* MACRO05
+* MACRO06
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/MicroQRVersion.md
+++ b/docs/Model/MicroQRVersion.md
@@ -1,0 +1,14 @@
+# MicroQRVersion
+
+MicroQR barcode version. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/microqrversion/
+## Allowable values
+
+* **AUTO**
+* M1
+* M2
+* M3
+* M4
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/Pdf417EncodeMode.md
+++ b/docs/Model/Pdf417EncodeMode.md
@@ -1,0 +1,13 @@
+# Pdf417EncodeMode
+
+PDF417 barcode encode mode. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/pdf417encodemode/
+## Allowable values
+
+* **AUTO**
+* BINARY
+* ECI
+* EXTENDED
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/Pdf417ErrorLevel.md
+++ b/docs/Model/Pdf417ErrorLevel.md
@@ -1,0 +1,18 @@
+# Pdf417ErrorLevel
+
+PDF417 barcode error correction level. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/pdf417errorlevel/
+## Allowable values
+
+* **LEVEL0**
+* LEVEL1
+* LEVEL2
+* LEVEL3
+* LEVEL4
+* LEVEL5
+* LEVEL6
+* LEVEL7
+* LEVEL8
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/Pdf417Params.md
+++ b/docs/Model/Pdf417Params.md
@@ -5,15 +5,15 @@ Optional PDF417 barcode generation parameters. Applies to Pdf417, MacroPdf417, M
 ## Properties
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
-**pdf417_encode_mode** | [**\Aspose\BarCode\Model\Pdf417EncodeMode**](Pdf417EncodeMode.md) |  | [optional] 
-**pdf417_error_level** | [**\Aspose\BarCode\Model\Pdf417ErrorLevel**](Pdf417ErrorLevel.md) |  | [optional] 
+**pdf417_encode_mode** | [**\Aspose\BarCode\Model\Pdf417EncodeMode**](Pdf417EncodeMode.md) | PDF417 barcode encode mode. | [optional] 
+**pdf417_error_level** | [**\Aspose\BarCode\Model\Pdf417ErrorLevel**](Pdf417ErrorLevel.md) | PDF417 barcode error correction level. | [optional] 
 **pdf417_truncate** | **bool** | Whether to use truncated PDF417 format (removes right-side stop pattern). | [optional] 
 **pdf417_columns** | **int** | Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto. | [optional] 
 **pdf417_rows** | **int** | Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic. | [optional] 
 **pdf417_aspect_ratio** | **float** | PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417. | [optional] 
-**pdf417_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](ECIEncodings.md) |  | [optional] 
+**pdf417_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](ECIEncodings.md) | ECI encoding for PDF417 barcode data. | [optional] 
 **pdf417_is_reader_initialization** | **bool** | Whether the barcode is used for reader initialization (programming). | [optional] 
-**pdf417_macro_characters** | [**\Aspose\BarCode\Model\MacroCharacter**](MacroCharacter.md) |  | [optional] 
+**pdf417_macro_characters** | [**\Aspose\BarCode\Model\MacroCharacter**](MacroCharacter.md) | Macro character to prepend (structured append). | [optional] 
 **pdf417_is_linked** | **bool** | Whether to use linked mode (for MicroPdf417). | [optional] 
 **pdf417_is_code128_emulation** | **bool** | Whether to use Code128 emulation for MicroPdf417. | [optional] 
 

--- a/docs/Model/Pdf417Params.md
+++ b/docs/Model/Pdf417Params.md
@@ -1,0 +1,22 @@
+# Pdf417Params
+
+Optional PDF417 barcode generation parameters. Applies to Pdf417, MacroPdf417, MicroPdf417, and GS1MicroPdf417 barcode types.
+
+## Properties
+Name | Type | Description | Notes
+---- | ---- | ----------- | -----
+**pdf417_encode_mode** | [**\Aspose\BarCode\Model\Pdf417EncodeMode**](Pdf417EncodeMode.md) |  | [optional] 
+**pdf417_error_level** | [**\Aspose\BarCode\Model\Pdf417ErrorLevel**](Pdf417ErrorLevel.md) |  | [optional] 
+**pdf417_truncate** | **bool** | Whether to use truncated PDF417 format (removes right-side stop pattern). | [optional] 
+**pdf417_columns** | **int** | Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto. | [optional] 
+**pdf417_rows** | **int** | Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic. | [optional] 
+**pdf417_aspect_ratio** | **float** | PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417. | [optional] 
+**pdf417_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](ECIEncodings.md) |  | [optional] 
+**pdf417_is_reader_initialization** | **bool** | Whether the barcode is used for reader initialization (programming). | [optional] 
+**pdf417_macro_characters** | [**\Aspose\BarCode\Model\MacroCharacter**](MacroCharacter.md) |  | [optional] 
+**pdf417_is_linked** | **bool** | Whether to use linked mode (for MicroPdf417). | [optional] 
+**pdf417_is_code128_emulation** | **bool** | Whether to use Code128 emulation for MicroPdf417. | [optional] 
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/QREncodeMode.md
+++ b/docs/Model/QREncodeMode.md
@@ -1,0 +1,13 @@
+# QREncodeMode
+
+QR barcode encode mode. Subset of https://reference.aspose.com/barcode/net/aspose.barcode.generation/qrencodemode/ Obsolete members (Bytes, Utf8BOM, Utf16BEBOM, ECIEncoding, ExtendedCodetext) are omitted.
+## Allowable values
+
+* **AUTO**
+* EXTENDED
+* BINARY
+* ECI
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/QRErrorLevel.md
+++ b/docs/Model/QRErrorLevel.md
@@ -1,0 +1,13 @@
+# QRErrorLevel
+
+QR barcode error correction level. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/qrerrorlevel/
+## Allowable values
+
+* **LEVEL_L**
+* LEVEL_M
+* LEVEL_Q
+* LEVEL_H
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/QRVersion.md
+++ b/docs/Model/QRVersion.md
@@ -1,0 +1,50 @@
+# QRVersion
+
+QR barcode version. Subset of https://reference.aspose.com/barcode/net/aspose.barcode.generation/qrversion/ MicroQR versions (VersionM1–VersionM4) are omitted; use Aspose.BarCode.Cloud.DTO.Enums.MicroQRVersion instead.
+## Allowable values
+
+* **AUTO**
+* VERSION01
+* VERSION02
+* VERSION03
+* VERSION04
+* VERSION05
+* VERSION06
+* VERSION07
+* VERSION08
+* VERSION09
+* VERSION10
+* VERSION11
+* VERSION12
+* VERSION13
+* VERSION14
+* VERSION15
+* VERSION16
+* VERSION17
+* VERSION18
+* VERSION19
+* VERSION20
+* VERSION21
+* VERSION22
+* VERSION23
+* VERSION24
+* VERSION25
+* VERSION26
+* VERSION27
+* VERSION28
+* VERSION29
+* VERSION30
+* VERSION31
+* VERSION32
+* VERSION33
+* VERSION34
+* VERSION35
+* VERSION36
+* VERSION37
+* VERSION38
+* VERSION39
+* VERSION40
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/QrParams.md
+++ b/docs/Model/QrParams.md
@@ -1,0 +1,18 @@
+# QrParams
+
+Optional QR barcode generation parameters. Applies to QR, GS1QR, MicroQR, and RectMicroQR barcode types.
+
+## Properties
+Name | Type | Description | Notes
+---- | ---- | ----------- | -----
+**qr_encode_mode** | [**\Aspose\BarCode\Model\QREncodeMode**](QREncodeMode.md) |  | [optional] 
+**qr_error_level** | [**\Aspose\BarCode\Model\QRErrorLevel**](QRErrorLevel.md) |  | [optional] 
+**qr_version** | [**\Aspose\BarCode\Model\QRVersion**](QRVersion.md) |  | [optional] 
+**qr_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](ECIEncodings.md) |  | [optional] 
+**qr_aspect_ratio** | **float** | QR barcode aspect ratio. Values: 0 to 1. | [optional] 
+**micro_qr_version** | [**\Aspose\BarCode\Model\MicroQRVersion**](MicroQRVersion.md) |  | [optional] 
+**rect_micro_qr_version** | [**\Aspose\BarCode\Model\RectMicroQRVersion**](RectMicroQRVersion.md) |  | [optional] 
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/docs/Model/QrParams.md
+++ b/docs/Model/QrParams.md
@@ -5,13 +5,13 @@ Optional QR barcode generation parameters. Applies to QR, GS1QR, MicroQR, and Re
 ## Properties
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
-**qr_encode_mode** | [**\Aspose\BarCode\Model\QREncodeMode**](QREncodeMode.md) |  | [optional] 
-**qr_error_level** | [**\Aspose\BarCode\Model\QRErrorLevel**](QRErrorLevel.md) |  | [optional] 
-**qr_version** | [**\Aspose\BarCode\Model\QRVersion**](QRVersion.md) |  | [optional] 
-**qr_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](ECIEncodings.md) |  | [optional] 
+**qr_encode_mode** | [**\Aspose\BarCode\Model\QREncodeMode**](QREncodeMode.md) | QR barcode encode mode. | [optional] 
+**qr_error_level** | [**\Aspose\BarCode\Model\QRErrorLevel**](QRErrorLevel.md) | QR barcode error correction level. | [optional] 
+**qr_version** | [**\Aspose\BarCode\Model\QRVersion**](QRVersion.md) | QR barcode version. Automatically selects the smallest version that fits the data. | [optional] 
+**qr_eci_encoding** | [**\Aspose\BarCode\Model\ECIEncodings**](ECIEncodings.md) | ECI encoding for QR barcode data. | [optional] 
 **qr_aspect_ratio** | **float** | QR barcode aspect ratio. Values: 0 to 1. | [optional] 
-**micro_qr_version** | [**\Aspose\BarCode\Model\MicroQRVersion**](MicroQRVersion.md) |  | [optional] 
-**rect_micro_qr_version** | [**\Aspose\BarCode\Model\RectMicroQRVersion**](RectMicroQRVersion.md) |  | [optional] 
+**micro_qr_version** | [**\Aspose\BarCode\Model\MicroQRVersion**](MicroQRVersion.md) | MicroQR barcode version. Used when BarcodeType is MicroQR. | [optional] 
+**rect_micro_qr_version** | [**\Aspose\BarCode\Model\RectMicroQRVersion**](RectMicroQRVersion.md) | RectMicroQR barcode version. Used when BarcodeType is RectMicroQR. | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/RecognizeBase64Request.md
+++ b/docs/Model/RecognizeBase64Request.md
@@ -1,11 +1,11 @@
 # RecognizeBase64Request
 
-Barcode recognize request
+Barcode recognition request.
 
 ## Properties
 Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
-**barcode_types** | [**\Aspose\BarCode\Model\DecodeBarcodeType[]**](DecodeBarcodeType.md) | Array of decode types to find on barcode | 
+**barcode_types** | [**\Aspose\BarCode\Model\DecodeBarcodeType[]**](DecodeBarcodeType.md) | Array of barcode decode types to find. | 
 **file_base64** | **string** | Barcode image bytes encoded as base-64. | 
 **recognition_mode** | [**\Aspose\BarCode\Model\RecognitionMode**](RecognitionMode.md) |  | [optional] 
 **recognition_image_kind** | [**\Aspose\BarCode\Model\RecognitionImageKind**](RecognitionImageKind.md) |  | [optional] 

--- a/docs/Model/RecognizeBase64Request.md
+++ b/docs/Model/RecognizeBase64Request.md
@@ -7,8 +7,8 @@ Name | Type | Description | Notes
 ---- | ---- | ----------- | -----
 **barcode_types** | [**\Aspose\BarCode\Model\DecodeBarcodeType[]**](DecodeBarcodeType.md) | Array of barcode decode types to find. | 
 **file_base64** | **string** | Barcode image bytes encoded as base-64. | 
-**recognition_mode** | [**\Aspose\BarCode\Model\RecognitionMode**](RecognitionMode.md) |  | [optional] 
-**recognition_image_kind** | [**\Aspose\BarCode\Model\RecognitionImageKind**](RecognitionImageKind.md) |  | [optional] 
+**recognition_mode** | [**\Aspose\BarCode\Model\RecognitionMode**](RecognitionMode.md) | Barcode recognition mode. | [optional] 
+**recognition_image_kind** | [**\Aspose\BarCode\Model\RecognitionImageKind**](RecognitionImageKind.md) | Image kind for recognition. | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/docs/Model/RectMicroQRVersion.md
+++ b/docs/Model/RectMicroQRVersion.md
@@ -1,0 +1,42 @@
+# RectMicroQRVersion
+
+RectMicroQR barcode version. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/rectmicroqrversion/
+## Allowable values
+
+* **AUTO**
+* R7X43
+* R7X59
+* R7X77
+* R7X99
+* R7X139
+* R9X43
+* R9X59
+* R9X77
+* R9X99
+* R9X139
+* R11X27
+* R11X43
+* R11X59
+* R11X77
+* R11X99
+* R11X139
+* R13X27
+* R13X43
+* R13X59
+* R13X77
+* R13X99
+* R13X139
+* R15X43
+* R15X59
+* R15X77
+* R15X99
+* R15X139
+* R17X43
+* R17X59
+* R17X77
+* R17X99
+* R17X139
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@ require __DIR__ . '/vendor/autoload.php';
 use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
 use Aspose\BarCode\Requests\GenerateRequestWrapper;
-use Aspose\BarCode\Model\{EncodeBarcodeType, EncodeDataType, CodeLocation, BarcodeImageFormat};
+use Aspose\BarCode\Model\{EncodeBarcodeType, EncodeDataType, CodeLocation, BarcodeImageFormat, QREncodeMode, QRErrorLevel, QRVersion};
 
 $config = new Configuration();
 $config->setClientId('ClientId from https://dashboard.aspose.cloud/applications');
@@ -19,6 +19,10 @@ if (getenv("TEST_CONFIGURATION_ACCESS_TOKEN")) {
 $request = new GenerateRequestWrapper(EncodeBarcodeType::QR, 'PHP SDK Test');
 $request->image_format = BarcodeImageFormat::Png;
 $request->text_location = CodeLocation::None;
+$request->qr_encode_mode = QREncodeMode::Auto;
+$request->qr_error_level = QRErrorLevel::LevelM;
+$request->qr_version = QRVersion::Auto;
+$request->qr_aspect_ratio = 0.75;
 
 $api = new GenerateApi(null, $config);
 $response = $api->generate($request);

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@ require __DIR__ . '/vendor/autoload.php';
 use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
 use Aspose\BarCode\Requests\GenerateRequestWrapper;
-use Aspose\BarCode\Model\{EncodeBarcodeType, EncodeDataType, CodeLocation, BarcodeImageFormat, QREncodeMode, QRErrorLevel, QRVersion};
+use Aspose\BarCode\Model\{BarcodeImageParams, EncodeBarcodeType, EncodeDataType, CodeLocation, BarcodeImageFormat, QrParams, QREncodeMode, QRErrorLevel, QRVersion};
 
 $config = new Configuration();
 $config->setClientId('ClientId from https://dashboard.aspose.cloud/applications');
@@ -17,12 +17,14 @@ if (getenv("TEST_CONFIGURATION_ACCESS_TOKEN")) {
 }
 
 $request = new GenerateRequestWrapper(EncodeBarcodeType::QR, 'PHP SDK Test');
-$request->image_format = BarcodeImageFormat::Png;
-$request->text_location = CodeLocation::None;
-$request->qr_encode_mode = QREncodeMode::Auto;
-$request->qr_error_level = QRErrorLevel::LevelM;
-$request->qr_version = QRVersion::Auto;
-$request->qr_aspect_ratio = 0.75;
+$request->barcode_image_params = new BarcodeImageParams();
+$request->barcode_image_params->setImageFormat(BarcodeImageFormat::Png);
+$request->barcode_image_params->setTextLocation(CodeLocation::None);
+$request->qr_params = new QrParams();
+$request->qr_params->setQrEncodeMode(QREncodeMode::Auto);
+$request->qr_params->setQrErrorLevel(QRErrorLevel::LevelM);
+$request->qr_params->setQrVersion(QRVersion::Auto);
+$request->qr_params->setQrAspectRatio(0.75);
 
 $api = new GenerateApi(null, $config);
 $response = $api->generate($request);

--- a/scripts/add-screaming-snake-enum-aliases.bash
+++ b/scripts/add-screaming-snake-enum-aliases.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+MODEL_DIR="$( cd "${SCRIPT_DIR}/../src/Aspose/BarCode/Model" &> /dev/null && pwd )"
+
+find "${MODEL_DIR}" -name "*.php" -exec python "${SCRIPT_DIR}/add-screaming-snake-enum-aliases.py" "{}" \;

--- a/scripts/add-screaming-snake-enum-aliases.py
+++ b/scripts/add-screaming-snake-enum-aliases.py
@@ -1,0 +1,79 @@
+"""Add SCREAMING_SNAKE_CASE constant aliases to PHP enum classes.
+
+openapi-generator's PHP modelEnum template emits constants named exactly after
+the spec values (e.g. ``public const Png = "Png"``), but the default-value
+reference in non-enum models is rendered as ``BarcodeImageFormat::PNG`` (the
+screaming-snake of the value). The two disagree, so phpstan flags
+``Aspose\\BarCode\\Model\\BarcodeImageFormat::PNG`` as undefined.
+
+This script adds an alias constant pointing to the *original* wire string,
+e.g. ``public const PNG = "Png"``. Wire values are unchanged, the backend
+needs no update, and other-language SDKs are untouched.
+
+Idempotent. Only enum-shaped class members are touched; regular models pass
+through unchanged because their constants don't have const-name == value.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+_CONST_RE = re.compile(r'^(?P<indent>\s*)public const (?P<name>\w+) =\s+"(?P<value>\w+)";\s*$')
+_LOWER_TO_UPPER = re.compile(r"([a-z0-9])([A-Z])")
+_UPPER_TO_PASCAL = re.compile(r"([A-Z])([A-Z][a-z])")
+
+
+def screaming_snake(name: str) -> str:
+    """Convert PascalCase / camelCase to SCREAMING_SNAKE_CASE."""
+    name = _LOWER_TO_UPPER.sub(r"\1_\2", name)
+    name = _UPPER_TO_PASCAL.sub(r"\1_\2", name)
+    return name.upper()
+
+
+def process(path: Path) -> bool:
+    """Add aliases in-place. Return True iff the file changed."""
+    original = path.read_text(encoding="utf-8")
+    lines = original.splitlines(keepends=True)
+
+    # Collect every existing const name so we never produce a duplicate.
+    existing: set[str] = set()
+    for line in lines:
+        match = _CONST_RE.match(line)
+        if match:
+            existing.add(match.group("name"))
+
+    out: list[str] = []
+    for line in lines:
+        out.append(line)
+        match = _CONST_RE.match(line)
+        if match is None:
+            continue
+        name, value, indent = match.group("name"), match.group("value"), match.group("indent")
+        # Only touch enum constants — the openapi-generator template emits the
+        # constant name identical to the wire value for these.
+        if name != value:
+            continue
+        alias = screaming_snake(value)
+        if alias == name or alias in existing:
+            continue
+        existing.add(alias)
+        out.append(f'{indent}public const {alias} = "{value}";\n')
+
+    updated = "".join(out)
+    if updated == original:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_file", type=Path)
+    args = parser.parse_args()
+    process(args.input_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/insert-example.bash
+++ b/scripts/insert-example.bash
@@ -3,6 +3,9 @@ set -euo pipefail
 
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
-python "./scripts/insert-example.py" "README.template" > "README.md"
+tmp_readme="$(mktemp README.md.XXXXXX)"
+trap 'rm -f "$tmp_readme"' EXIT
 
-rm "README.template"
+python3 "./scripts/insert-example.py" "README.template" > "$tmp_readme"
+mv "$tmp_readme" "README.md"
+trap - EXIT

--- a/scripts/insert-example.bash
+++ b/scripts/insert-example.bash
@@ -8,4 +8,5 @@ trap 'rm -f "$tmp_readme"' EXIT
 
 python3 "./scripts/insert-example.py" "README.template" > "$tmp_readme"
 mv "$tmp_readme" "README.md"
+rm -f "README.template"
 trap - EXIT

--- a/snippets/generate/appearance/GenerateBody.php
+++ b/snippets/generate/appearance/GenerateBody.php
@@ -6,7 +6,7 @@ require 'vendor/autoload.php';
 
 use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
-use Aspose\BarCode\Model\{GenerateParams, EncodeBarcodeType, EncodeData, EncodeDataType, BarcodeImageParams, BarcodeImageFormat};
+use Aspose\BarCode\Model\{GenerateParams, EncodeBarcodeType, EncodeData, EncodeDataType, BarcodeImageParams, BarcodeImageFormat, QrParams, QREncodeMode, QRErrorLevel, QRVersion};
 use Aspose\BarCode\Requests\GenerateBodyRequestWrapper;
 
 function makeConfiguration(): Configuration
@@ -26,12 +26,12 @@ function makeConfiguration(): Configuration
 
 function main(): void
 {
-    $fileName = __DIR__ . "/../testdata/Code39.jpeg";
+    $fileName = __DIR__ . "/../testdata/QrCustom.jpeg";
 
     $generateApi = new GenerateApi(null, makeConfiguration());
 
     $generateParams = new GenerateParams([
-        'barcode_type' => EncodeBarcodeType::Code39,
+        'barcode_type' => EncodeBarcodeType::QR,
         'encode_data' => new EncodeData([
             'data' => 'Aspose',
             'data_type' => EncodeDataType::StringData
@@ -41,6 +41,12 @@ function main(): void
             'background_color' => '#FFFF00',
             'image_format' => BarcodeImageFormat::Jpeg,
             'rotation_angle' => 90
+        ]),
+        'qr_params' => new QrParams([
+            'qr_encode_mode' => QREncodeMode::Auto,
+            'qr_error_level' => QRErrorLevel::LevelM,
+            'qr_version' => QRVersion::Auto,
+            'qr_aspect_ratio' => 0.75
         ])
     ]);
 

--- a/snippets/generate/appearance/GenerateGet.php
+++ b/snippets/generate/appearance/GenerateGet.php
@@ -6,7 +6,7 @@ require 'vendor/autoload.php';
 
 use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
-use Aspose\BarCode\Model\{BarcodeImageFormat, CodeLocation, EncodeBarcodeType};
+use Aspose\BarCode\Model\{BarcodeImageFormat, BarcodeImageParams, CodeLocation, EncodeBarcodeType, QrParams, QREncodeMode, QRErrorLevel, QRVersion};
 use Aspose\BarCode\Requests\GenerateRequestWrapper;
 
 function makeConfiguration(): Configuration
@@ -34,13 +34,21 @@ function main(): void
         EncodeBarcodeType::QR,
         'Aspose.BarCode.Cloud'
     );
-    $request->image_format = BarcodeImageFormat::Png;
-    $request->foreground_color = 'Black';
-    $request->background_color = 'White';
-    $request->text_location = CodeLocation::Below;
-    $request->resolution = 300;
-    $request->image_height = 200;
-    $request->image_width = 200;
+    $request->barcode_image_params = new BarcodeImageParams([
+        'image_format' => BarcodeImageFormat::Png,
+        'foreground_color' => 'Black',
+        'background_color' => 'White',
+        'text_location' => CodeLocation::Below,
+        'resolution' => 300,
+        'image_height' => 200,
+        'image_width' => 200
+    ]);
+    $request->qr_params = new QrParams([
+        'qr_encode_mode' => QREncodeMode::Auto,
+        'qr_error_level' => QRErrorLevel::LevelM,
+        'qr_version' => QRVersion::Auto,
+        'qr_aspect_ratio' => 0.75
+    ]);
 
     $generated = $generateApi->generate($request);
 

--- a/snippets/generate/appearance/GenerateMultipart.php
+++ b/snippets/generate/appearance/GenerateMultipart.php
@@ -6,7 +6,7 @@ require 'vendor/autoload.php';
 
 use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
-use Aspose\BarCode\Model\{BarcodeImageFormat};
+use Aspose\BarCode\Model\{BarcodeImageFormat, BarcodeImageParams, CodeLocation, Pdf417Params, Pdf417EncodeMode, Pdf417ErrorLevel};
 use Aspose\BarCode\Requests\GenerateMultipartRequestWrapper;
 use Aspose\BarCode\Model\EncodeBarcodeType;
 
@@ -35,8 +35,15 @@ function main(): void
         EncodeBarcodeType::Pdf417,
         "Aspose.BarCode.Cloud"
     );
-    $request->text_location = "Above";
-    $request->image_format = BarcodeImageFormat::Svg;
+    $request->barcode_image_params = new BarcodeImageParams([
+        'text_location' => CodeLocation::Above,
+        'image_format' => BarcodeImageFormat::Svg
+    ]);
+    $request->pdf417_params = new Pdf417Params([
+        'pdf417_encode_mode' => Pdf417EncodeMode::Auto,
+        'pdf417_error_level' => Pdf417ErrorLevel::Level2,
+        'pdf417_aspect_ratio' => 3
+    ]);
 
     $barcodeStream = $generateApi->generateMultipart($request);
 

--- a/snippets/generate/save/GenerateGet.php
+++ b/snippets/generate/save/GenerateGet.php
@@ -6,7 +6,7 @@ require 'vendor/autoload.php';
 
 use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
-use Aspose\BarCode\Model\{BarcodeImageFormat, EncodeBarcodeType};
+use Aspose\BarCode\Model\{BarcodeImageFormat, BarcodeImageParams, Code128Params, Code128EncodeMode, EncodeBarcodeType};
 use Aspose\BarCode\Requests\GenerateRequestWrapper;
 
 function makeConfiguration(): Configuration
@@ -31,7 +31,12 @@ function main(): void
     $generateApi = new GenerateApi(null, makeConfiguration());
 
     $request = new GenerateRequestWrapper(EncodeBarcodeType::Code128, "Aspose.BarCode.Cloud");
-    $request->image_format = BarcodeImageFormat::Png;
+    $request->barcode_image_params = new BarcodeImageParams([
+        'image_format' => BarcodeImageFormat::Png
+    ]);
+    $request->code128_params = new Code128Params([
+        'code128_encode_mode' => Code128EncodeMode::Auto
+    ]);
 
     $generated = $generateApi->generate($request);
 

--- a/snippets/generate/set-colorscheme/GenerateGet.php
+++ b/snippets/generate/set-colorscheme/GenerateGet.php
@@ -39,9 +39,11 @@ function main(): void
         EncodeBarcodeType::QR,
         "https://products.aspose.cloud/barcode/family/"
     );
-    $request->foreground_color = "DarkBlue";
-    $request->background_color = "LightGray";
-    $request->image_format = BarcodeImageFormat::Png;
+    $request->barcode_image_params = new BarcodeImageParams([
+        'foreground_color' => "DarkBlue",
+        'background_color' => "LightGray",
+        'image_format' => BarcodeImageFormat::Png
+    ]);
 
     $generated = $generateApi->generate($request);
 

--- a/snippets/generate/set-colorscheme/GenerateMultipart.php
+++ b/snippets/generate/set-colorscheme/GenerateMultipart.php
@@ -6,7 +6,7 @@ require 'vendor/autoload.php';
 
 use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
-use Aspose\BarCode\Model\{BarcodeImageFormat, EncodeBarcodeType};
+use Aspose\BarCode\Model\{BarcodeImageFormat, BarcodeImageParams, EncodeBarcodeType};
 use Aspose\BarCode\Requests\GenerateMultipartRequestWrapper;
 
 function makeConfiguration(): Configuration
@@ -31,9 +31,11 @@ function main(): void
     $generateApi = new GenerateApi(null, makeConfiguration());
 
     $request = new GenerateMultipartRequestWrapper(EncodeBarcodeType::Code39, "Aspose");
-    $request->foreground_color = "Green";
-    $request->background_color = "Yellow";
-    $request->image_format = BarcodeImageFormat::Gif;
+    $request->barcode_image_params = new BarcodeImageParams([
+        'foreground_color' => "Green",
+        'background_color' => "Yellow",
+        'image_format' => BarcodeImageFormat::Gif
+    ]);
 
     $generated = $generateApi->generateMultipart($request);
 

--- a/snippets/generate/set-size/GenerateGet.php
+++ b/snippets/generate/set-size/GenerateGet.php
@@ -6,7 +6,7 @@ require 'vendor/autoload.php';
 
 use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
-use Aspose\BarCode\Model\{BarcodeImageParams, EncodeBarcodeType};
+use Aspose\BarCode\Model\{BarcodeImageParams, EncodeBarcodeType, GraphicsUnit};
 use Aspose\BarCode\Requests\GenerateRequestWrapper;
 
 function makeConfiguration(): Configuration
@@ -31,11 +31,12 @@ function main(): void
     $generateApi = new GenerateApi(null, makeConfiguration());
 
     $request = new GenerateRequestWrapper(EncodeBarcodeType::QR, "Aspose.BarCode.Cloud");
-    $request->image_height = 200;
-    $request->image_width = 200;
-    $request->resolution = 300;
-    $request->units = 'Pixel';
-
+    $request->barcode_image_params = new BarcodeImageParams([
+        'image_height' => 200,
+        'image_width' => 200,
+        'resolution' => 300,
+        'units' => GraphicsUnit::Pixel
+    ]);
 
     $generated = $generateApi->generate($request);
 

--- a/snippets/generate/set-size/GenerateMultipart.php
+++ b/snippets/generate/set-size/GenerateMultipart.php
@@ -8,6 +8,7 @@ use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
 use Aspose\BarCode\Model\BarcodeImageParams;
 use Aspose\BarCode\Model\EncodeBarcodeType;
+use Aspose\BarCode\Model\GraphicsUnit;
 use Aspose\BarCode\Requests\GenerateMultipartRequestWrapper;
 
 function makeConfiguration(): Configuration
@@ -32,10 +33,12 @@ function main(): void
     $generateApi = new GenerateApi(null, makeConfiguration());
 
     $request = new GenerateMultipartRequestWrapper(EncodeBarcodeType::Aztec, "Aspose.BarCode.Cloud");
-    $request->image_height = 200;
-    $request->image_width = 200;
-    $request->resolution = 150;
-    $request->units = 'Point';
+    $request->barcode_image_params = new BarcodeImageParams([
+        'image_height' => 200,
+        'image_width' => 200,
+        'resolution' => 150,
+        'units' => GraphicsUnit::Point
+    ]);
 
     $generated = $generateApi->generateMultipart($request);
 

--- a/snippets/generate/set-text/GenerateMultipart.php
+++ b/snippets/generate/set-text/GenerateMultipart.php
@@ -7,7 +7,7 @@ require 'vendor/autoload.php';
 use Aspose\BarCode\Configuration;
 use Aspose\BarCode\GenerateApi;
 use Aspose\BarCode\Requests\GenerateMultipartRequestWrapper;
-use Aspose\BarCode\Model\{EncodeBarcodeType, EncodeDataType};
+use Aspose\BarCode\Model\{EncodeBarcodeType, EncodeDataType, Code128Params, Code128EncodeMode};
 
 function makeConfiguration(): Configuration
 {
@@ -32,6 +32,9 @@ function main(): void
 
     $formRequest = new GenerateMultipartRequestWrapper(EncodeBarcodeType::Code128, "4173706F73652E426172436F64652E436C6F7564");
     $formRequest->data_type = EncodeDataType::HexBytes;
+    $formRequest->code128_params = new Code128Params([
+        'code128_encode_mode' => Code128EncodeMode::Auto
+    ]);
 
     $generated = $generateApi->generateMultipart($formRequest);
 

--- a/snippets/read/set-image-kind/RecognizeBody.php
+++ b/snippets/read/set-image-kind/RecognizeBody.php
@@ -33,7 +33,7 @@ function main()
     $base64Request = new RecognizeBase64Request([
         'barcode_types' => [DecodeBarcodeType::Aztec, DecodeBarcodeType::QR],
         'file_base64' => $imageBase64,
-        'image_kind' => RecognitionImageKind::ScannedDocument
+        'recognition_image_kind' => RecognitionImageKind::ScannedDocument
     ]);
 
     $request = new RecognizeBase64RequestWrapper($base64Request);

--- a/snippets/read/set-image-kind/RecognizeGet.php
+++ b/snippets/read/set-image-kind/RecognizeGet.php
@@ -27,7 +27,7 @@ function main()
     $recognizeApi = new RecognizeApi(null, makeConfiguration());
 
     $request = new RecognizeRequestWrapper(DecodeBarcodeType::QR, "https://products.aspose.app/barcode/scan/img/how-to/scan/step2.png");
-    $request->image_kind = RecognitionImageKind::Photo;
+    $request->recognition_image_kind = RecognitionImageKind::Photo;
 
     $result = $recognizeApi->recognize($request);
 

--- a/snippets/read/set-image-kind/RecognizeMultipart.php
+++ b/snippets/read/set-image-kind/RecognizeMultipart.php
@@ -29,7 +29,7 @@ function main()
     $fileName = __DIR__ . '/../testdata/Pdf417.png';
     $file = new SplFileObject($fileName, 'rb');
     $request = new RecognizeMultipartRequestWrapper(DecodeBarcodeType::MostCommonlyUsed, $file);
-    $request->image_kind = RecognitionImageKind::ClearImage;
+    $request->recognition_image_kind = RecognitionImageKind::ClearImage;
 
     $result = $recognizeApi->recognizeMultipart($request);
 

--- a/snippets/read/set-quality/RecognizeGet.php
+++ b/snippets/read/set-quality/RecognizeGet.php
@@ -28,7 +28,7 @@ function main()
 
     $request = new RecognizeRequestWrapper(DecodeBarcodeType::QR, "https://products.aspose.app/barcode/scan/img/how-to/scan/step2.png");
     $request->recognition_mode = RecognitionMode::Fast;
-    $request->image_kind = RecognitionImageKind::Photo;
+    $request->recognition_image_kind = RecognitionImageKind::Photo;
 
     $result = $recognizeApi->recognize($request);
 

--- a/snippets/read/set-quality/RecognizeMultipart.php
+++ b/snippets/read/set-quality/RecognizeMultipart.php
@@ -31,7 +31,7 @@ function main()
 
     $request = new RecognizeMultipartRequestWrapper(DecodeBarcodeType::Aztec, $file);
     $request->recognition_mode = RecognitionMode::Normal;
-    $request->image_kind = RecognitionImageKind::ScannedDocument;
+    $request->recognition_image_kind = RecognitionImageKind::ScannedDocument;
 
     $result = $recognizeApi->recognizeMultipart($request);
 

--- a/src/Aspose/BarCode/Configuration.php
+++ b/src/Aspose/BarCode/Configuration.php
@@ -20,7 +20,7 @@ class Configuration implements JsonSerializable
      *
      * @var string
      */
-    protected $clientVersion = '26.5.0';
+    protected $clientVersion = '26.6.0';
 
     /**
      * ClientId for API

--- a/src/Aspose/BarCode/GenerateApi.php
+++ b/src/Aspose/BarCode/GenerateApi.php
@@ -90,7 +90,7 @@ class GenerateApi
     /**
      * Operation generate
      *
-     * Generate barcode using GET request with parameters in route and query string.
+     * Generate a barcode using a GET request with parameters in the route and query string.
      *
      * @param Requests\GenerateRequestWrapper $request is a request object for operation
      *
@@ -112,7 +112,7 @@ class GenerateApi
     /**
      * Operation generateWithHttpInfo
      *
-     * Generate barcode using GET request with parameters in route and query string.
+     * Generate a barcode using a GET request with parameters in the route and query string.
      *
      * @param Requests\GenerateRequestWrapper $request is a request object for operation
      *
@@ -176,7 +176,7 @@ class GenerateApi
     /**
      * Operation generateAsync
      *
-     * Generate barcode using GET request with parameters in route and query string.
+     * Generate a barcode using a GET request with parameters in the route and query string.
      *
      * @param Requests\GenerateRequestWrapper $request is a request object for operation
      *
@@ -196,7 +196,7 @@ class GenerateApi
     /**
      * Operation generateAsyncWithHttpInfo
      *
-     * Generate barcode using GET request with parameters in route and query string.
+     * Generate a barcode using a GET request with parameters in the route and query string.
      *
      * @param Requests\GenerateRequestWrapper $request is a request object for operation
      *
@@ -274,6 +274,34 @@ class GenerateApi
         }
         if (isset($request->resolution) && $request->resolution < 1) {
             throw new InvalidArgumentException("invalid value for resolution when calling GenerateApi.generate, must be bigger than or equal to 1.");
+        }
+
+        if (isset($request->qr_aspect_ratio) && $request->qr_aspect_ratio > 1) {
+            throw new InvalidArgumentException("invalid value for qr_aspect_ratio when calling GenerateApi.generate, must be smaller than or equal to 1.");
+        }
+        if (isset($request->qr_aspect_ratio) && $request->qr_aspect_ratio < 0.001) {
+            throw new InvalidArgumentException("invalid value for qr_aspect_ratio when calling GenerateApi.generate, must be bigger than or equal to 0.001.");
+        }
+
+        if (isset($request->pdf417_columns) && $request->pdf417_columns > 30) {
+            throw new InvalidArgumentException("invalid value for pdf417_columns when calling GenerateApi.generate, must be smaller than or equal to 30.");
+        }
+        if (isset($request->pdf417_columns) && $request->pdf417_columns < 0) {
+            throw new InvalidArgumentException("invalid value for pdf417_columns when calling GenerateApi.generate, must be bigger than or equal to 0.");
+        }
+
+        if (isset($request->pdf417_rows) && $request->pdf417_rows > 90) {
+            throw new InvalidArgumentException("invalid value for pdf417_rows when calling GenerateApi.generate, must be smaller than or equal to 90.");
+        }
+        if (isset($request->pdf417_rows) && $request->pdf417_rows < 0) {
+            throw new InvalidArgumentException("invalid value for pdf417_rows when calling GenerateApi.generate, must be bigger than or equal to 0.");
+        }
+
+        if (isset($request->pdf417_aspect_ratio) && $request->pdf417_aspect_ratio > 10) {
+            throw new InvalidArgumentException("invalid value for pdf417_aspect_ratio when calling GenerateApi.generate, must be smaller than or equal to 10.");
+        }
+        if (isset($request->pdf417_aspect_ratio) && $request->pdf417_aspect_ratio < 2) {
+            throw new InvalidArgumentException("invalid value for pdf417_aspect_ratio when calling GenerateApi.generate, must be bigger than or equal to 2.");
         }
 
 
@@ -386,6 +414,177 @@ class GenerateApi
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
+        if (isset($request->qr_encode_mode)) {
+            $queryParamName = lcfirst('qrEncodeMode');
+            $queryParamValue = is_bool($request->qr_encode_mode) ? ($request->qr_encode_mode ? 'true' : 'false') : $request->qr_encode_mode;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->qr_error_level)) {
+            $queryParamName = lcfirst('qrErrorLevel');
+            $queryParamValue = is_bool($request->qr_error_level) ? ($request->qr_error_level ? 'true' : 'false') : $request->qr_error_level;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->qr_version)) {
+            $queryParamName = lcfirst('qrVersion');
+            $queryParamValue = is_bool($request->qr_version) ? ($request->qr_version ? 'true' : 'false') : $request->qr_version;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->qr_eci_encoding)) {
+            $queryParamName = lcfirst('qrECIEncoding');
+            $queryParamValue = is_bool($request->qr_eci_encoding) ? ($request->qr_eci_encoding ? 'true' : 'false') : $request->qr_eci_encoding;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->qr_aspect_ratio)) {
+            $queryParamName = lcfirst('qrAspectRatio');
+            $queryParamValue = is_bool($request->qr_aspect_ratio) ? ($request->qr_aspect_ratio ? 'true' : 'false') : $request->qr_aspect_ratio;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->micro_qr_version)) {
+            $queryParamName = lcfirst('microQRVersion');
+            $queryParamValue = is_bool($request->micro_qr_version) ? ($request->micro_qr_version ? 'true' : 'false') : $request->micro_qr_version;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->rect_micro_qr_version)) {
+            $queryParamName = lcfirst('rectMicroQrVersion');
+            $queryParamValue = is_bool($request->rect_micro_qr_version) ? ($request->rect_micro_qr_version ? 'true' : 'false') : $request->rect_micro_qr_version;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->code128_encode_mode)) {
+            $queryParamName = lcfirst('code128EncodeMode');
+            $queryParamValue = is_bool($request->code128_encode_mode) ? ($request->code128_encode_mode ? 'true' : 'false') : $request->code128_encode_mode;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->pdf417_encode_mode)) {
+            $queryParamName = lcfirst('pdf417EncodeMode');
+            $queryParamValue = is_bool($request->pdf417_encode_mode) ? ($request->pdf417_encode_mode ? 'true' : 'false') : $request->pdf417_encode_mode;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->pdf417_error_level)) {
+            $queryParamName = lcfirst('pdf417ErrorLevel');
+            $queryParamValue = is_bool($request->pdf417_error_level) ? ($request->pdf417_error_level ? 'true' : 'false') : $request->pdf417_error_level;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->pdf417_truncate)) {
+            $queryParamName = lcfirst('pdf417Truncate');
+            $queryParamValue = is_bool($request->pdf417_truncate) ? ($request->pdf417_truncate ? 'true' : 'false') : $request->pdf417_truncate;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->pdf417_columns)) {
+            $queryParamName = lcfirst('pdf417Columns');
+            $queryParamValue = is_bool($request->pdf417_columns) ? ($request->pdf417_columns ? 'true' : 'false') : $request->pdf417_columns;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->pdf417_rows)) {
+            $queryParamName = lcfirst('pdf417Rows');
+            $queryParamValue = is_bool($request->pdf417_rows) ? ($request->pdf417_rows ? 'true' : 'false') : $request->pdf417_rows;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->pdf417_aspect_ratio)) {
+            $queryParamName = lcfirst('pdf417AspectRatio');
+            $queryParamValue = is_bool($request->pdf417_aspect_ratio) ? ($request->pdf417_aspect_ratio ? 'true' : 'false') : $request->pdf417_aspect_ratio;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->pdf417_eci_encoding)) {
+            $queryParamName = lcfirst('pdf417ECIEncoding');
+            $queryParamValue = is_bool($request->pdf417_eci_encoding) ? ($request->pdf417_eci_encoding ? 'true' : 'false') : $request->pdf417_eci_encoding;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->pdf417_is_reader_initialization)) {
+            $queryParamName = lcfirst('pdf417IsReaderInitialization');
+            $queryParamValue = is_bool($request->pdf417_is_reader_initialization) ? ($request->pdf417_is_reader_initialization ? 'true' : 'false') : $request->pdf417_is_reader_initialization;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->pdf417_macro_characters)) {
+            $queryParamName = lcfirst('pdf417MacroCharacters');
+            $queryParamValue = is_bool($request->pdf417_macro_characters) ? ($request->pdf417_macro_characters ? 'true' : 'false') : $request->pdf417_macro_characters;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->pdf417_is_linked)) {
+            $queryParamName = lcfirst('pdf417IsLinked');
+            $queryParamValue = is_bool($request->pdf417_is_linked) ? ($request->pdf417_is_linked ? 'true' : 'false') : $request->pdf417_is_linked;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
+        if (isset($request->pdf417_is_code128_emulation)) {
+            $queryParamName = lcfirst('pdf417IsCode128Emulation');
+            $queryParamValue = is_bool($request->pdf417_is_code128_emulation) ? ($request->pdf417_is_code128_emulation ? 'true' : 'false') : $request->pdf417_is_code128_emulation;
+            if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
+                $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
+            } else {
+                $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
+            }
+        }
 
         $resourcePath = $this->_parseURL($resourcePath, $queryParams);
 
@@ -439,7 +638,7 @@ class GenerateApi
     /**
      * Operation generateBody
      *
-     * Generate barcode using POST request with parameters in body in json or xml format.
+     * Generate a barcode using a POST request with parameters in the request body in JSON or XML format.
      *
      * @param Requests\GenerateBodyRequestWrapper $request is a request object for operation
      *
@@ -461,7 +660,7 @@ class GenerateApi
     /**
      * Operation generateBodyWithHttpInfo
      *
-     * Generate barcode using POST request with parameters in body in json or xml format.
+     * Generate a barcode using a POST request with parameters in the request body in JSON or XML format.
      *
      * @param Requests\GenerateBodyRequestWrapper $request is a request object for operation
      *
@@ -525,7 +724,7 @@ class GenerateApi
     /**
      * Operation generateBodyAsync
      *
-     * Generate barcode using POST request with parameters in body in json or xml format.
+     * Generate a barcode using a POST request with parameters in the request body in JSON or XML format.
      *
      * @param Requests\GenerateBodyRequestWrapper $request is a request object for operation
      *
@@ -545,7 +744,7 @@ class GenerateApi
     /**
      * Operation generateBodyAsyncWithHttpInfo
      *
-     * Generate barcode using POST request with parameters in body in json or xml format.
+     * Generate a barcode using a POST request with parameters in the request body in JSON or XML format.
      *
      * @param Requests\GenerateBodyRequestWrapper $request is a request object for operation
      *
@@ -687,7 +886,7 @@ class GenerateApi
     /**
      * Operation generateMultipart
      *
-     * Generate barcode using POST request with parameters in multipart form.
+     * Generate a barcode using a POST request with parameters in a multipart form.
      *
      * @param Requests\GenerateMultipartRequestWrapper $request is a request object for operation
      *
@@ -709,7 +908,7 @@ class GenerateApi
     /**
      * Operation generateMultipartWithHttpInfo
      *
-     * Generate barcode using POST request with parameters in multipart form.
+     * Generate a barcode using a POST request with parameters in a multipart form.
      *
      * @param Requests\GenerateMultipartRequestWrapper $request is a request object for operation
      *
@@ -773,7 +972,7 @@ class GenerateApi
     /**
      * Operation generateMultipartAsync
      *
-     * Generate barcode using POST request with parameters in multipart form.
+     * Generate a barcode using a POST request with parameters in a multipart form.
      *
      * @param Requests\GenerateMultipartRequestWrapper $request is a request object for operation
      *
@@ -793,7 +992,7 @@ class GenerateApi
     /**
      * Operation generateMultipartAsyncWithHttpInfo
      *
-     * Generate barcode using POST request with parameters in multipart form.
+     * Generate a barcode using a POST request with parameters in a multipart form.
      *
      * @param Requests\GenerateMultipartRequestWrapper $request is a request object for operation
      *
@@ -873,6 +1072,34 @@ class GenerateApi
             throw new InvalidArgumentException("invalid value for resolution when calling GenerateApi.generateMultipart, must be bigger than or equal to 1.");
         }
 
+        if (isset($request->qr_aspect_ratio) && $request->qr_aspect_ratio > 1) {
+            throw new InvalidArgumentException("invalid value for qr_aspect_ratio when calling GenerateApi.generateMultipart, must be smaller than or equal to 1.");
+        }
+        if (isset($request->qr_aspect_ratio) && $request->qr_aspect_ratio < 0.001) {
+            throw new InvalidArgumentException("invalid value for qr_aspect_ratio when calling GenerateApi.generateMultipart, must be bigger than or equal to 0.001.");
+        }
+
+        if (isset($request->pdf417_columns) && $request->pdf417_columns > 30) {
+            throw new InvalidArgumentException("invalid value for pdf417_columns when calling GenerateApi.generateMultipart, must be smaller than or equal to 30.");
+        }
+        if (isset($request->pdf417_columns) && $request->pdf417_columns < 0) {
+            throw new InvalidArgumentException("invalid value for pdf417_columns when calling GenerateApi.generateMultipart, must be bigger than or equal to 0.");
+        }
+
+        if (isset($request->pdf417_rows) && $request->pdf417_rows > 90) {
+            throw new InvalidArgumentException("invalid value for pdf417_rows when calling GenerateApi.generateMultipart, must be smaller than or equal to 90.");
+        }
+        if (isset($request->pdf417_rows) && $request->pdf417_rows < 0) {
+            throw new InvalidArgumentException("invalid value for pdf417_rows when calling GenerateApi.generateMultipart, must be bigger than or equal to 0.");
+        }
+
+        if (isset($request->pdf417_aspect_ratio) && $request->pdf417_aspect_ratio > 10) {
+            throw new InvalidArgumentException("invalid value for pdf417_aspect_ratio when calling GenerateApi.generateMultipart, must be smaller than or equal to 10.");
+        }
+        if (isset($request->pdf417_aspect_ratio) && $request->pdf417_aspect_ratio < 2) {
+            throw new InvalidArgumentException("invalid value for pdf417_aspect_ratio when calling GenerateApi.generateMultipart, must be bigger than or equal to 2.");
+        }
+
 
         $resourcePath = '/barcode/generate-multipart';
         $formParams = [];
@@ -931,6 +1158,82 @@ class GenerateApi
 
         if (isset($request->rotation_angle)) {
             $formParams['rotationAngle'][] = ObjectSerializer::toFormValue($request->rotation_angle);
+        }
+
+        if (isset($request->qr_encode_mode)) {
+            $formParams['qrEncodeMode'][] = ObjectSerializer::toFormValue($request->qr_encode_mode);
+        }
+
+        if (isset($request->qr_error_level)) {
+            $formParams['qrErrorLevel'][] = ObjectSerializer::toFormValue($request->qr_error_level);
+        }
+
+        if (isset($request->qr_version)) {
+            $formParams['qrVersion'][] = ObjectSerializer::toFormValue($request->qr_version);
+        }
+
+        if (isset($request->qr_eci_encoding)) {
+            $formParams['qrECIEncoding'][] = ObjectSerializer::toFormValue($request->qr_eci_encoding);
+        }
+
+        if (isset($request->qr_aspect_ratio)) {
+            $formParams['qrAspectRatio'][] = ObjectSerializer::toFormValue($request->qr_aspect_ratio);
+        }
+
+        if (isset($request->micro_qr_version)) {
+            $formParams['microQRVersion'][] = ObjectSerializer::toFormValue($request->micro_qr_version);
+        }
+
+        if (isset($request->rect_micro_qr_version)) {
+            $formParams['rectMicroQrVersion'][] = ObjectSerializer::toFormValue($request->rect_micro_qr_version);
+        }
+
+        if (isset($request->code128_encode_mode)) {
+            $formParams['code128EncodeMode'][] = ObjectSerializer::toFormValue($request->code128_encode_mode);
+        }
+
+        if (isset($request->pdf417_encode_mode)) {
+            $formParams['pdf417EncodeMode'][] = ObjectSerializer::toFormValue($request->pdf417_encode_mode);
+        }
+
+        if (isset($request->pdf417_error_level)) {
+            $formParams['pdf417ErrorLevel'][] = ObjectSerializer::toFormValue($request->pdf417_error_level);
+        }
+
+        if (isset($request->pdf417_truncate)) {
+            $formParams['pdf417Truncate'][] = ObjectSerializer::toFormValue($request->pdf417_truncate);
+        }
+
+        if (isset($request->pdf417_columns)) {
+            $formParams['pdf417Columns'][] = ObjectSerializer::toFormValue($request->pdf417_columns);
+        }
+
+        if (isset($request->pdf417_rows)) {
+            $formParams['pdf417Rows'][] = ObjectSerializer::toFormValue($request->pdf417_rows);
+        }
+
+        if (isset($request->pdf417_aspect_ratio)) {
+            $formParams['pdf417AspectRatio'][] = ObjectSerializer::toFormValue($request->pdf417_aspect_ratio);
+        }
+
+        if (isset($request->pdf417_eci_encoding)) {
+            $formParams['pdf417ECIEncoding'][] = ObjectSerializer::toFormValue($request->pdf417_eci_encoding);
+        }
+
+        if (isset($request->pdf417_is_reader_initialization)) {
+            $formParams['pdf417IsReaderInitialization'][] = ObjectSerializer::toFormValue($request->pdf417_is_reader_initialization);
+        }
+
+        if (isset($request->pdf417_macro_characters)) {
+            $formParams['pdf417MacroCharacters'][] = ObjectSerializer::toFormValue($request->pdf417_macro_characters);
+        }
+
+        if (isset($request->pdf417_is_linked)) {
+            $formParams['pdf417IsLinked'][] = ObjectSerializer::toFormValue($request->pdf417_is_linked);
+        }
+
+        if (isset($request->pdf417_is_code128_emulation)) {
+            $formParams['pdf417IsCode128Emulation'][] = ObjectSerializer::toFormValue($request->pdf417_is_code128_emulation);
         }
         // body params
         $_tempBody = null;

--- a/src/Aspose/BarCode/GenerateApi.php
+++ b/src/Aspose/BarCode/GenerateApi.php
@@ -333,252 +333,280 @@ class GenerateApi
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->image_format)) {
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['image_format'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('imageFormat');
-            $queryParamValue = is_bool($request->image_format) ? ($request->image_format ? 'true' : 'false') : $request->image_format;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->text_location)) {
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['text_location'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('textLocation');
-            $queryParamValue = is_bool($request->text_location) ? ($request->text_location ? 'true' : 'false') : $request->text_location;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->foreground_color)) {
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['foreground_color'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('foregroundColor');
-            $queryParamValue = is_bool($request->foreground_color) ? ($request->foreground_color ? 'true' : 'false') : $request->foreground_color;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->background_color)) {
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['background_color'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('backgroundColor');
-            $queryParamValue = is_bool($request->background_color) ? ($request->background_color ? 'true' : 'false') : $request->background_color;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->units)) {
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['units'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('units');
-            $queryParamValue = is_bool($request->units) ? ($request->units ? 'true' : 'false') : $request->units;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->resolution)) {
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['resolution'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('resolution');
-            $queryParamValue = is_bool($request->resolution) ? ($request->resolution ? 'true' : 'false') : $request->resolution;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->image_height)) {
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['image_height'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('imageHeight');
-            $queryParamValue = is_bool($request->image_height) ? ($request->image_height ? 'true' : 'false') : $request->image_height;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->image_width)) {
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['image_width'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('imageWidth');
-            $queryParamValue = is_bool($request->image_width) ? ($request->image_width ? 'true' : 'false') : $request->image_width;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->rotation_angle)) {
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['rotation_angle'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('rotationAngle');
-            $queryParamValue = is_bool($request->rotation_angle) ? ($request->rotation_angle ? 'true' : 'false') : $request->rotation_angle;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->qr_encode_mode)) {
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['qr_encode_mode'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('qrEncodeMode');
-            $queryParamValue = is_bool($request->qr_encode_mode) ? ($request->qr_encode_mode ? 'true' : 'false') : $request->qr_encode_mode;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->qr_error_level)) {
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['qr_error_level'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('qrErrorLevel');
-            $queryParamValue = is_bool($request->qr_error_level) ? ($request->qr_error_level ? 'true' : 'false') : $request->qr_error_level;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->qr_version)) {
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['qr_version'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('qrVersion');
-            $queryParamValue = is_bool($request->qr_version) ? ($request->qr_version ? 'true' : 'false') : $request->qr_version;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->qr_eci_encoding)) {
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['qr_eci_encoding'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('qrECIEncoding');
-            $queryParamValue = is_bool($request->qr_eci_encoding) ? ($request->qr_eci_encoding ? 'true' : 'false') : $request->qr_eci_encoding;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->qr_aspect_ratio)) {
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['qr_aspect_ratio'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('qrAspectRatio');
-            $queryParamValue = is_bool($request->qr_aspect_ratio) ? ($request->qr_aspect_ratio ? 'true' : 'false') : $request->qr_aspect_ratio;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->micro_qr_version)) {
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['micro_qr_version'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('microQRVersion');
-            $queryParamValue = is_bool($request->micro_qr_version) ? ($request->micro_qr_version ? 'true' : 'false') : $request->micro_qr_version;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->rect_micro_qr_version)) {
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['rect_micro_qr_version'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('rectMicroQrVersion');
-            $queryParamValue = is_bool($request->rect_micro_qr_version) ? ($request->rect_micro_qr_version ? 'true' : 'false') : $request->rect_micro_qr_version;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->code128_encode_mode)) {
+        $groupValue = $request->code128_params === null ? null : $request->code128_params['code128_encode_mode'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('code128EncodeMode');
-            $queryParamValue = is_bool($request->code128_encode_mode) ? ($request->code128_encode_mode ? 'true' : 'false') : $request->code128_encode_mode;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->pdf417_encode_mode)) {
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_encode_mode'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('pdf417EncodeMode');
-            $queryParamValue = is_bool($request->pdf417_encode_mode) ? ($request->pdf417_encode_mode ? 'true' : 'false') : $request->pdf417_encode_mode;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->pdf417_error_level)) {
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_error_level'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('pdf417ErrorLevel');
-            $queryParamValue = is_bool($request->pdf417_error_level) ? ($request->pdf417_error_level ? 'true' : 'false') : $request->pdf417_error_level;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->pdf417_truncate)) {
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_truncate'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('pdf417Truncate');
-            $queryParamValue = is_bool($request->pdf417_truncate) ? ($request->pdf417_truncate ? 'true' : 'false') : $request->pdf417_truncate;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->pdf417_columns)) {
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_columns'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('pdf417Columns');
-            $queryParamValue = is_bool($request->pdf417_columns) ? ($request->pdf417_columns ? 'true' : 'false') : $request->pdf417_columns;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->pdf417_rows)) {
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_rows'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('pdf417Rows');
-            $queryParamValue = is_bool($request->pdf417_rows) ? ($request->pdf417_rows ? 'true' : 'false') : $request->pdf417_rows;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->pdf417_aspect_ratio)) {
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_aspect_ratio'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('pdf417AspectRatio');
-            $queryParamValue = is_bool($request->pdf417_aspect_ratio) ? ($request->pdf417_aspect_ratio ? 'true' : 'false') : $request->pdf417_aspect_ratio;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->pdf417_eci_encoding)) {
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_eci_encoding'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('pdf417ECIEncoding');
-            $queryParamValue = is_bool($request->pdf417_eci_encoding) ? ($request->pdf417_eci_encoding ? 'true' : 'false') : $request->pdf417_eci_encoding;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->pdf417_is_reader_initialization)) {
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_is_reader_initialization'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('pdf417IsReaderInitialization');
-            $queryParamValue = is_bool($request->pdf417_is_reader_initialization) ? ($request->pdf417_is_reader_initialization ? 'true' : 'false') : $request->pdf417_is_reader_initialization;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->pdf417_macro_characters)) {
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_macro_characters'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('pdf417MacroCharacters');
-            $queryParamValue = is_bool($request->pdf417_macro_characters) ? ($request->pdf417_macro_characters ? 'true' : 'false') : $request->pdf417_macro_characters;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->pdf417_is_linked)) {
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_is_linked'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('pdf417IsLinked');
-            $queryParamValue = is_bool($request->pdf417_is_linked) ? ($request->pdf417_is_linked ? 'true' : 'false') : $request->pdf417_is_linked;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
                 $queryParams[$queryParamName] = ObjectSerializer::toQueryValue($queryParamValue);
             }
         }
-        if (isset($request->pdf417_is_code128_emulation)) {
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_is_code128_emulation'];
+        if (isset($groupValue)) {
             $queryParamName = lcfirst('pdf417IsCode128Emulation');
-            $queryParamValue = is_bool($request->pdf417_is_code128_emulation) ? ($request->pdf417_is_code128_emulation ? 'true' : 'false') : $request->pdf417_is_code128_emulation;
+            $queryParamValue = is_bool($groupValue) ? ($groupValue ? 'true' : 'false') : $groupValue;
             if (strpos($resourcePath, '{' . $queryParamName . '}') !== false) {
                 $resourcePath = str_replace('{' . $queryParamName . '}', ObjectSerializer::toPathValue($queryParamValue), $resourcePath);
             } else {
@@ -1124,116 +1152,144 @@ class GenerateApi
             $formParams['data'][] = ObjectSerializer::toFormValue($request->data);
         }
 
-        if (isset($request->image_format)) {
-            $formParams['imageFormat'][] = ObjectSerializer::toFormValue($request->image_format);
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['image_format'];
+        if (isset($groupValue)) {
+            $formParams['imageFormat'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->text_location)) {
-            $formParams['textLocation'][] = ObjectSerializer::toFormValue($request->text_location);
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['text_location'];
+        if (isset($groupValue)) {
+            $formParams['textLocation'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->foreground_color)) {
-            $formParams['foregroundColor'][] = ObjectSerializer::toFormValue($request->foreground_color);
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['foreground_color'];
+        if (isset($groupValue)) {
+            $formParams['foregroundColor'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->background_color)) {
-            $formParams['backgroundColor'][] = ObjectSerializer::toFormValue($request->background_color);
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['background_color'];
+        if (isset($groupValue)) {
+            $formParams['backgroundColor'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->units)) {
-            $formParams['units'][] = ObjectSerializer::toFormValue($request->units);
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['units'];
+        if (isset($groupValue)) {
+            $formParams['units'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->resolution)) {
-            $formParams['resolution'][] = ObjectSerializer::toFormValue($request->resolution);
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['resolution'];
+        if (isset($groupValue)) {
+            $formParams['resolution'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->image_height)) {
-            $formParams['imageHeight'][] = ObjectSerializer::toFormValue($request->image_height);
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['image_height'];
+        if (isset($groupValue)) {
+            $formParams['imageHeight'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->image_width)) {
-            $formParams['imageWidth'][] = ObjectSerializer::toFormValue($request->image_width);
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['image_width'];
+        if (isset($groupValue)) {
+            $formParams['imageWidth'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->rotation_angle)) {
-            $formParams['rotationAngle'][] = ObjectSerializer::toFormValue($request->rotation_angle);
+        $groupValue = $request->barcode_image_params === null ? null : $request->barcode_image_params['rotation_angle'];
+        if (isset($groupValue)) {
+            $formParams['rotationAngle'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->qr_encode_mode)) {
-            $formParams['qrEncodeMode'][] = ObjectSerializer::toFormValue($request->qr_encode_mode);
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['qr_encode_mode'];
+        if (isset($groupValue)) {
+            $formParams['qrEncodeMode'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->qr_error_level)) {
-            $formParams['qrErrorLevel'][] = ObjectSerializer::toFormValue($request->qr_error_level);
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['qr_error_level'];
+        if (isset($groupValue)) {
+            $formParams['qrErrorLevel'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->qr_version)) {
-            $formParams['qrVersion'][] = ObjectSerializer::toFormValue($request->qr_version);
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['qr_version'];
+        if (isset($groupValue)) {
+            $formParams['qrVersion'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->qr_eci_encoding)) {
-            $formParams['qrECIEncoding'][] = ObjectSerializer::toFormValue($request->qr_eci_encoding);
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['qr_eci_encoding'];
+        if (isset($groupValue)) {
+            $formParams['qrECIEncoding'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->qr_aspect_ratio)) {
-            $formParams['qrAspectRatio'][] = ObjectSerializer::toFormValue($request->qr_aspect_ratio);
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['qr_aspect_ratio'];
+        if (isset($groupValue)) {
+            $formParams['qrAspectRatio'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->micro_qr_version)) {
-            $formParams['microQRVersion'][] = ObjectSerializer::toFormValue($request->micro_qr_version);
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['micro_qr_version'];
+        if (isset($groupValue)) {
+            $formParams['microQRVersion'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->rect_micro_qr_version)) {
-            $formParams['rectMicroQrVersion'][] = ObjectSerializer::toFormValue($request->rect_micro_qr_version);
+        $groupValue = $request->qr_params === null ? null : $request->qr_params['rect_micro_qr_version'];
+        if (isset($groupValue)) {
+            $formParams['rectMicroQrVersion'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->code128_encode_mode)) {
-            $formParams['code128EncodeMode'][] = ObjectSerializer::toFormValue($request->code128_encode_mode);
+        $groupValue = $request->code128_params === null ? null : $request->code128_params['code128_encode_mode'];
+        if (isset($groupValue)) {
+            $formParams['code128EncodeMode'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->pdf417_encode_mode)) {
-            $formParams['pdf417EncodeMode'][] = ObjectSerializer::toFormValue($request->pdf417_encode_mode);
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_encode_mode'];
+        if (isset($groupValue)) {
+            $formParams['pdf417EncodeMode'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->pdf417_error_level)) {
-            $formParams['pdf417ErrorLevel'][] = ObjectSerializer::toFormValue($request->pdf417_error_level);
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_error_level'];
+        if (isset($groupValue)) {
+            $formParams['pdf417ErrorLevel'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->pdf417_truncate)) {
-            $formParams['pdf417Truncate'][] = ObjectSerializer::toFormValue($request->pdf417_truncate);
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_truncate'];
+        if (isset($groupValue)) {
+            $formParams['pdf417Truncate'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->pdf417_columns)) {
-            $formParams['pdf417Columns'][] = ObjectSerializer::toFormValue($request->pdf417_columns);
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_columns'];
+        if (isset($groupValue)) {
+            $formParams['pdf417Columns'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->pdf417_rows)) {
-            $formParams['pdf417Rows'][] = ObjectSerializer::toFormValue($request->pdf417_rows);
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_rows'];
+        if (isset($groupValue)) {
+            $formParams['pdf417Rows'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->pdf417_aspect_ratio)) {
-            $formParams['pdf417AspectRatio'][] = ObjectSerializer::toFormValue($request->pdf417_aspect_ratio);
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_aspect_ratio'];
+        if (isset($groupValue)) {
+            $formParams['pdf417AspectRatio'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->pdf417_eci_encoding)) {
-            $formParams['pdf417ECIEncoding'][] = ObjectSerializer::toFormValue($request->pdf417_eci_encoding);
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_eci_encoding'];
+        if (isset($groupValue)) {
+            $formParams['pdf417ECIEncoding'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->pdf417_is_reader_initialization)) {
-            $formParams['pdf417IsReaderInitialization'][] = ObjectSerializer::toFormValue($request->pdf417_is_reader_initialization);
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_is_reader_initialization'];
+        if (isset($groupValue)) {
+            $formParams['pdf417IsReaderInitialization'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->pdf417_macro_characters)) {
-            $formParams['pdf417MacroCharacters'][] = ObjectSerializer::toFormValue($request->pdf417_macro_characters);
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_macro_characters'];
+        if (isset($groupValue)) {
+            $formParams['pdf417MacroCharacters'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->pdf417_is_linked)) {
-            $formParams['pdf417IsLinked'][] = ObjectSerializer::toFormValue($request->pdf417_is_linked);
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_is_linked'];
+        if (isset($groupValue)) {
+            $formParams['pdf417IsLinked'][] = ObjectSerializer::toFormValue($groupValue);
         }
 
-        if (isset($request->pdf417_is_code128_emulation)) {
-            $formParams['pdf417IsCode128Emulation'][] = ObjectSerializer::toFormValue($request->pdf417_is_code128_emulation);
+        $groupValue = $request->pdf417_params === null ? null : $request->pdf417_params['pdf417_is_code128_emulation'];
+        if (isset($groupValue)) {
+            $formParams['pdf417IsCode128Emulation'][] = ObjectSerializer::toFormValue($groupValue);
         }
         // body params
         $_tempBody = null;

--- a/src/Aspose/BarCode/Model/ApiError.php
+++ b/src/Aspose/BarCode/Model/ApiError.php
@@ -321,7 +321,7 @@ class ApiError implements ArrayAccess
     /**
      * Sets inner_error
      *
-     * @param \Aspose\BarCode\Model\ApiError $inner_error inner_error
+     * @param \Aspose\BarCode\Model\ApiError $inner_error Gets or sets inner error.
      *
      * @return $this
      */
@@ -335,7 +335,7 @@ class ApiError implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -347,7 +347,7 @@ class ApiError implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -360,8 +360,8 @@ class ApiError implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -377,7 +377,7 @@ class ApiError implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/ApiErrorResponse.php
+++ b/src/Aspose/BarCode/Model/ApiErrorResponse.php
@@ -231,7 +231,7 @@ class ApiErrorResponse implements ArrayAccess
     /**
      * Sets error
      *
-     * @param \Aspose\BarCode\Model\ApiError $error error
+     * @param \Aspose\BarCode\Model\ApiError $error Gets or sets error.
      *
      * @return $this
      */
@@ -245,7 +245,7 @@ class ApiErrorResponse implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -257,7 +257,7 @@ class ApiErrorResponse implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -270,8 +270,8 @@ class ApiErrorResponse implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -287,7 +287,7 @@ class ApiErrorResponse implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/BarcodeImageFormat.php
+++ b/src/Aspose/BarCode/Model/BarcodeImageFormat.php
@@ -17,25 +17,30 @@ class BarcodeImageFormat
     /// Enum value Png
     /// </summary>
     public const Png =  "Png";
+    public const PNG = "Png";
 
     /// <summary>
     /// Enum value Jpeg
     /// </summary>
     public const Jpeg =  "Jpeg";
+    public const JPEG = "Jpeg";
 
     /// <summary>
     /// Enum value Svg
     /// </summary>
     public const Svg =  "Svg";
+    public const SVG = "Svg";
 
     /// <summary>
     /// Enum value Tiff
     /// </summary>
     public const Tiff =  "Tiff";
+    public const TIFF = "Tiff";
 
     /// <summary>
     /// Enum value Gif
     /// </summary>
     public const Gif =  "Gif";
+    public const GIF = "Gif";
 
 }

--- a/src/Aspose/BarCode/Model/BarcodeImageParams.php
+++ b/src/Aspose/BarCode/Model/BarcodeImageParams.php
@@ -189,7 +189,7 @@ class BarcodeImageParams implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['image_format'] = isset($data['image_format']) ? $data['image_format'] : null;
+        $this->container['image_format'] = isset($data['image_format']) ? $data['image_format'] : BarcodeImageFormat::PNG;
         $this->container['text_location'] = isset($data['text_location']) ? $data['text_location'] : null;
         $this->container['foreground_color'] = isset($data['foreground_color']) ? $data['foreground_color'] : 'Black';
         $this->container['background_color'] = isset($data['background_color']) ? $data['background_color'] : 'White';
@@ -251,7 +251,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Sets image_format
      *
-     * @param \Aspose\BarCode\Model\BarcodeImageFormat $image_format image_format
+     * @param \Aspose\BarCode\Model\BarcodeImageFormat $image_format Barcode output image format. Default value: png.
      *
      * @return $this
      */
@@ -275,7 +275,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Sets text_location
      *
-     * @param \Aspose\BarCode\Model\CodeLocation $text_location text_location
+     * @param \Aspose\BarCode\Model\CodeLocation $text_location Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes.
      *
      * @return $this
      */
@@ -347,7 +347,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Sets units
      *
-     * @param \Aspose\BarCode\Model\GraphicsUnit $units units
+     * @param \Aspose\BarCode\Model\GraphicsUnit $units Common units for all measurements. Default units: pixels.
      *
      * @return $this
      */
@@ -465,7 +465,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -477,7 +477,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -490,8 +490,8 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -507,7 +507,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/BarcodeImageParams.php
+++ b/src/Aspose/BarCode/Model/BarcodeImageParams.php
@@ -10,7 +10,7 @@ use Aspose\BarCode\ObjectSerializer;
 /**
  * BarcodeImageParams
  *
- * @description Barcode image optional parameters
+ * @description Optional barcode image parameters.
  */
 class BarcodeImageParams implements ArrayAccess
 {
@@ -299,7 +299,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Sets foreground_color
      *
-     * @param string $foreground_color Specify the displaying bars and content Color. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: Black.
+     * @param string $foreground_color Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
      *
      * @return $this
      */
@@ -323,7 +323,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Sets background_color
      *
-     * @param string $background_color Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: White.
+     * @param string $background_color Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
      *
      * @return $this
      */
@@ -371,7 +371,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Sets resolution
      *
-     * @param float $resolution Resolution of the BarCode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is dot.
+     * @param float $resolution Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
      *
      * @return $this
      */
@@ -403,7 +403,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Sets image_height
      *
-     * @param float $image_height Height of the barcode image in given units. Default units: pixel. Decimal separator is dot.
+     * @param float $image_height Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
      *
      * @return $this
      */
@@ -427,7 +427,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Sets image_width
      *
-     * @param float $image_width Width of the barcode image in given units. Default units: pixel. Decimal separator is dot.
+     * @param float $image_width Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
      *
      * @return $this
      */
@@ -451,7 +451,7 @@ class BarcodeImageParams implements ArrayAccess
     /**
      * Sets rotation_angle
      *
-     * @param int $rotation_angle BarCode image rotation angle, measured in degree, e.g. RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle NOT equal to 90, 180, 270 or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
+     * @param int $rotation_angle Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
      *
      * @return $this
      */

--- a/src/Aspose/BarCode/Model/BarcodeResponse.php
+++ b/src/Aspose/BarCode/Model/BarcodeResponse.php
@@ -293,7 +293,7 @@ class BarcodeResponse implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -305,7 +305,7 @@ class BarcodeResponse implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -318,8 +318,8 @@ class BarcodeResponse implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -335,7 +335,7 @@ class BarcodeResponse implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/BarcodeResponse.php
+++ b/src/Aspose/BarCode/Model/BarcodeResponse.php
@@ -10,7 +10,7 @@ use Aspose\BarCode\ObjectSerializer;
 /**
  * BarcodeResponse
  *
- * @description Represents information about barcode.
+ * @description Represents information about a barcode.
  */
 class BarcodeResponse implements ArrayAccess
 {
@@ -255,7 +255,7 @@ class BarcodeResponse implements ArrayAccess
     /**
      * Sets region
      *
-     * @param \Aspose\BarCode\Model\RegionPoint[] $region Region with barcode.
+     * @param \Aspose\BarCode\Model\RegionPoint[] $region Region with the barcode.
      *
      * @return $this
      */
@@ -279,7 +279,7 @@ class BarcodeResponse implements ArrayAccess
     /**
      * Sets checksum
      *
-     * @param string $checksum Checksum of barcode.
+     * @param string $checksum Checksum of the barcode.
      *
      * @return $this
      */

--- a/src/Aspose/BarCode/Model/BarcodeResponseList.php
+++ b/src/Aspose/BarCode/Model/BarcodeResponseList.php
@@ -209,7 +209,7 @@ class BarcodeResponseList implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -221,7 +221,7 @@ class BarcodeResponseList implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -234,8 +234,8 @@ class BarcodeResponseList implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -251,7 +251,7 @@ class BarcodeResponseList implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/BarcodeResponseList.php
+++ b/src/Aspose/BarCode/Model/BarcodeResponseList.php
@@ -10,7 +10,7 @@ use Aspose\BarCode\ObjectSerializer;
 /**
  * BarcodeResponseList
  *
- * @description Represents information about barcode list.
+ * @description Represents information about a barcode list.
  */
 class BarcodeResponseList implements ArrayAccess
 {
@@ -195,7 +195,7 @@ class BarcodeResponseList implements ArrayAccess
     /**
      * Sets barcodes
      *
-     * @param \Aspose\BarCode\Model\BarcodeResponse[] $barcodes List of barcodes which are present in image.
+     * @param \Aspose\BarCode\Model\BarcodeResponse[] $barcodes List of barcodes that are present in the image.
      *
      * @return $this
      */

--- a/src/Aspose/BarCode/Model/Code128EncodeMode.php
+++ b/src/Aspose/BarCode/Model/Code128EncodeMode.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * Code128EncodeMode
+ *
+ * @description Code128 barcode encode mode. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/code128encodemode/
+ */
+class Code128EncodeMode
+{
+    /// <summary>
+    /// Enum value Auto
+    /// </summary>
+    public const Auto =  "Auto";
+
+    /// <summary>
+    /// Enum value CodeA
+    /// </summary>
+    public const CodeA =  "CodeA";
+
+    /// <summary>
+    /// Enum value CodeB
+    /// </summary>
+    public const CodeB =  "CodeB";
+
+    /// <summary>
+    /// Enum value CodeAB
+    /// </summary>
+    public const CodeAB =  "CodeAB";
+
+    /// <summary>
+    /// Enum value CodeC
+    /// </summary>
+    public const CodeC =  "CodeC";
+
+    /// <summary>
+    /// Enum value CodeAC
+    /// </summary>
+    public const CodeAC =  "CodeAC";
+
+    /// <summary>
+    /// Enum value CodeBC
+    /// </summary>
+    public const CodeBC =  "CodeBC";
+
+}

--- a/src/Aspose/BarCode/Model/Code128EncodeMode.php
+++ b/src/Aspose/BarCode/Model/Code128EncodeMode.php
@@ -17,35 +17,42 @@ class Code128EncodeMode
     /// Enum value Auto
     /// </summary>
     public const Auto =  "Auto";
+    public const AUTO = "Auto";
 
     /// <summary>
     /// Enum value CodeA
     /// </summary>
     public const CodeA =  "CodeA";
+    public const CODE_A = "CodeA";
 
     /// <summary>
     /// Enum value CodeB
     /// </summary>
     public const CodeB =  "CodeB";
+    public const CODE_B = "CodeB";
 
     /// <summary>
     /// Enum value CodeAB
     /// </summary>
     public const CodeAB =  "CodeAB";
+    public const CODE_AB = "CodeAB";
 
     /// <summary>
     /// Enum value CodeC
     /// </summary>
     public const CodeC =  "CodeC";
+    public const CODE_C = "CodeC";
 
     /// <summary>
     /// Enum value CodeAC
     /// </summary>
     public const CodeAC =  "CodeAC";
+    public const CODE_AC = "CodeAC";
 
     /// <summary>
     /// Enum value CodeBC
     /// </summary>
     public const CodeBC =  "CodeBC";
+    public const CODE_BC = "CodeBC";
 
 }

--- a/src/Aspose/BarCode/Model/Code128Params.php
+++ b/src/Aspose/BarCode/Model/Code128Params.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use ArrayAccess;
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * Code128Params
+ *
+ * @description Optional Code128 barcode generation parameters.
+ */
+class Code128Params implements ArrayAccess
+{
+    public const DISCRIMINATOR = null;
+
+    /**
+     * The original name of the model.
+     *
+     * @var string
+     */
+    protected static string $swaggerModelName = "Code128Params";
+
+    /**
+     * Array of property to type mappings. Used for (de)serialization
+     *
+     * @var string[]
+     */
+    protected static array $swaggerTypes = [
+        'code128_encode_mode' => '\Aspose\BarCode\Model\Code128EncodeMode'
+    ];
+
+    /**
+     * Array of property to format mappings. Used for (de)serialization
+     *
+     * @var (string|null)[]
+     */
+    protected static array $swaggerFormats = [
+        'code128_encode_mode' => null
+    ];
+
+    /**
+     * Array of property to type mappings. Used for (de)serialization
+     *
+     * @return array
+     */
+    public static function swaggerTypes()
+    {
+        return self::$swaggerTypes;
+    }
+
+    /**
+     * Array of property to format mappings. Used for (de)serialization
+     *
+     * @return array
+     */
+    public static function swaggerFormats()
+    {
+        return self::$swaggerFormats;
+    }
+
+    /**
+     * Array of attributes where the key is the local name,
+     * and the value is the original name
+     *
+     * @var string[]
+     */
+    protected static $attributeMap = [
+        'code128_encode_mode' => 'code128EncodeMode'
+    ];
+
+    /**
+     * Array of attributes to setter functions (for deserialization of responses)
+     *
+     * @var string[]
+     */
+    protected static $setters = [
+        'code128_encode_mode' => 'setCode128EncodeMode'
+    ];
+
+    /**
+     * Array of attributes to getter functions (for serialization of requests)
+     *
+     * @var string[]
+     */
+    protected static $getters = [
+        'code128_encode_mode' => 'getCode128EncodeMode'
+    ];
+
+    /**
+     * Array of attributes where the key is the local name,
+     * and the value is the original name
+     *
+     * @return array
+     */
+    public static function attributeMap()
+    {
+        return self::$attributeMap;
+    }
+
+    /**
+     * Array of attributes to setter functions (for deserialization of responses)
+     *
+     * @return array
+     */
+    public static function setters()
+    {
+        return self::$setters;
+    }
+
+    /**
+     * Array of attributes to getter functions (for serialization of requests)
+     *
+     * @return array
+     */
+    public static function getters()
+    {
+        return self::$getters;
+    }
+
+    /**
+     * The original name of the model.
+     *
+     * @return string
+     */
+    public function getModelName()
+    {
+        return self::$swaggerModelName;
+    }
+
+
+
+
+
+    /**
+     * Associative array for storing property values
+     *
+     * @var mixed[]
+     */
+    protected $container = [];
+
+    /**
+     * Constructor
+     *
+     * @param mixed[] $data Associated array of property values
+     *                      initializing the model
+     */
+    public function __construct(?array $data = null)
+    {
+        $this->container['code128_encode_mode'] = isset($data['code128_encode_mode']) ? $data['code128_encode_mode'] : null;
+    }
+
+    /**
+     * Show all the invalid properties with reasons.
+     *
+     * @return array invalid properties with reasons
+     */
+    public function listInvalidProperties()
+    {
+        $invalidProperties = [];
+
+        return $invalidProperties;
+    }
+
+    /**
+     * Validate all the properties in the model
+     * return true if all passed
+     *
+     * @return bool True if all properties are valid
+     */
+    public function valid()
+    {
+        return true;
+    }
+
+
+    /**
+     * Gets code128_encode_mode
+     *
+     * @return \Aspose\BarCode\Model\Code128EncodeMode
+     */
+    public function getCode128EncodeMode()
+    {
+        return $this->container['code128_encode_mode'];
+    }
+
+    /**
+     * Sets code128_encode_mode
+     *
+     * @param \Aspose\BarCode\Model\Code128EncodeMode $code128_encode_mode code128_encode_mode
+     *
+     * @return $this
+     */
+    public function setCode128EncodeMode($code128_encode_mode)
+    {
+        $this->container['code128_encode_mode'] = $code128_encode_mode;
+
+        return $this;
+    }
+
+    /**
+     * Returns true if offset exists. False otherwise.
+     *
+     * @param integer $offset Offset
+     *
+     * @return boolean
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->container[$offset]);
+    }
+
+    /**
+     * Gets offset.
+     *
+     * @param integer $offset Offset
+     *
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        return $this->container[$offset] ?? null;
+    }
+
+    /**
+     * Sets value based on offset.
+     *
+     * @param integer $offset Offset
+     * @param mixed   $value  Value to be set
+     *
+     * @return void
+     */
+    public function offsetSet($offset, $value): void
+    {
+        if (is_null($offset)) {
+            $this->container[] = $value;
+        } else {
+            $this->container[$offset] = $value;
+        }
+    }
+
+    /**
+     * Unsets offset.
+     *
+     * @param integer $offset Offset
+     *
+     * @return void
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->container[$offset]);
+    }
+
+    /**
+     * Gets the string presentation of the object
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
+            return json_encode(
+                ObjectSerializer::sanitizeForSerialization($this),
+                JSON_PRETTY_PRINT
+            );
+        }
+
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
+}

--- a/src/Aspose/BarCode/Model/Code128Params.php
+++ b/src/Aspose/BarCode/Model/Code128Params.php
@@ -189,7 +189,7 @@ class Code128Params implements ArrayAccess
     /**
      * Sets code128_encode_mode
      *
-     * @param \Aspose\BarCode\Model\Code128EncodeMode $code128_encode_mode code128_encode_mode
+     * @param \Aspose\BarCode\Model\Code128EncodeMode $code128_encode_mode Code128 barcode encode mode. Controls which Code 128 subset (A, B, C, or mix) is used.
      *
      * @return $this
      */
@@ -203,7 +203,7 @@ class Code128Params implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -215,7 +215,7 @@ class Code128Params implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -228,8 +228,8 @@ class Code128Params implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -245,7 +245,7 @@ class Code128Params implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/CodeLocation.php
+++ b/src/Aspose/BarCode/Model/CodeLocation.php
@@ -16,15 +16,18 @@ class CodeLocation
     /// Enum value Below
     /// </summary>
     public const Below =  "Below";
+    public const BELOW = "Below";
 
     /// <summary>
     /// Enum value Above
     /// </summary>
     public const Above =  "Above";
+    public const ABOVE = "Above";
 
     /// <summary>
     /// Enum value None
     /// </summary>
     public const None =  "None";
+    public const NONE = "None";
 
 }

--- a/src/Aspose/BarCode/Model/DecodeBarcodeType.php
+++ b/src/Aspose/BarCode/Model/DecodeBarcodeType.php
@@ -9,7 +9,7 @@ use Aspose\BarCode\ObjectSerializer;
 /**
  * DecodeBarcodeType
  *
- * @description See Aspose.BarCode.BarCodeRecognition.DecodeType
+ * @description See https://reference.aspose.com/barcode/net/aspose.barcode.barcoderecognition/decodetype/
  */
 class DecodeBarcodeType
 {

--- a/src/Aspose/BarCode/Model/DecodeBarcodeType.php
+++ b/src/Aspose/BarCode/Model/DecodeBarcodeType.php
@@ -17,6 +17,7 @@ class DecodeBarcodeType
     /// Enum value MostCommonlyUsed
     /// </summary>
     public const MostCommonlyUsed =  "MostCommonlyUsed";
+    public const MOST_COMMONLY_USED = "MostCommonlyUsed";
 
     /// <summary>
     /// Enum value QR
@@ -27,131 +28,157 @@ class DecodeBarcodeType
     /// Enum value AustraliaPost
     /// </summary>
     public const AustraliaPost =  "AustraliaPost";
+    public const AUSTRALIA_POST = "AustraliaPost";
 
     /// <summary>
     /// Enum value AustralianPosteParcel
     /// </summary>
     public const AustralianPosteParcel =  "AustralianPosteParcel";
+    public const AUSTRALIAN_POSTE_PARCEL = "AustralianPosteParcel";
 
     /// <summary>
     /// Enum value Aztec
     /// </summary>
     public const Aztec =  "Aztec";
+    public const AZTEC = "Aztec";
 
     /// <summary>
     /// Enum value Codabar
     /// </summary>
     public const Codabar =  "Codabar";
+    public const CODABAR = "Codabar";
 
     /// <summary>
     /// Enum value CodablockF
     /// </summary>
     public const CodablockF =  "CodablockF";
+    public const CODABLOCK_F = "CodablockF";
 
     /// <summary>
     /// Enum value Code11
     /// </summary>
     public const Code11 =  "Code11";
+    public const CODE11 = "Code11";
 
     /// <summary>
     /// Enum value Code128
     /// </summary>
     public const Code128 =  "Code128";
+    public const CODE128 = "Code128";
 
     /// <summary>
     /// Enum value Code16K
     /// </summary>
     public const Code16K =  "Code16K";
+    public const CODE16_K = "Code16K";
 
     /// <summary>
     /// Enum value Code32
     /// </summary>
     public const Code32 =  "Code32";
+    public const CODE32 = "Code32";
 
     /// <summary>
     /// Enum value Code39
     /// </summary>
     public const Code39 =  "Code39";
+    public const CODE39 = "Code39";
 
     /// <summary>
     /// Enum value Code39FullASCII
     /// </summary>
     public const Code39FullASCII =  "Code39FullASCII";
+    public const CODE39_FULL_ASCII = "Code39FullASCII";
 
     /// <summary>
     /// Enum value Code93
     /// </summary>
     public const Code93 =  "Code93";
+    public const CODE93 = "Code93";
 
     /// <summary>
     /// Enum value CompactPdf417
     /// </summary>
     public const CompactPdf417 =  "CompactPdf417";
+    public const COMPACT_PDF417 = "CompactPdf417";
 
     /// <summary>
     /// Enum value DataLogic2of5
     /// </summary>
     public const DataLogic2of5 =  "DataLogic2of5";
+    public const DATA_LOGIC2OF5 = "DataLogic2of5";
 
     /// <summary>
     /// Enum value DataMatrix
     /// </summary>
     public const DataMatrix =  "DataMatrix";
+    public const DATA_MATRIX = "DataMatrix";
 
     /// <summary>
     /// Enum value DatabarExpanded
     /// </summary>
     public const DatabarExpanded =  "DatabarExpanded";
+    public const DATABAR_EXPANDED = "DatabarExpanded";
 
     /// <summary>
     /// Enum value DatabarExpandedStacked
     /// </summary>
     public const DatabarExpandedStacked =  "DatabarExpandedStacked";
+    public const DATABAR_EXPANDED_STACKED = "DatabarExpandedStacked";
 
     /// <summary>
     /// Enum value DatabarLimited
     /// </summary>
     public const DatabarLimited =  "DatabarLimited";
+    public const DATABAR_LIMITED = "DatabarLimited";
 
     /// <summary>
     /// Enum value DatabarOmniDirectional
     /// </summary>
     public const DatabarOmniDirectional =  "DatabarOmniDirectional";
+    public const DATABAR_OMNI_DIRECTIONAL = "DatabarOmniDirectional";
 
     /// <summary>
     /// Enum value DatabarStacked
     /// </summary>
     public const DatabarStacked =  "DatabarStacked";
+    public const DATABAR_STACKED = "DatabarStacked";
 
     /// <summary>
     /// Enum value DatabarStackedOmniDirectional
     /// </summary>
     public const DatabarStackedOmniDirectional =  "DatabarStackedOmniDirectional";
+    public const DATABAR_STACKED_OMNI_DIRECTIONAL = "DatabarStackedOmniDirectional";
 
     /// <summary>
     /// Enum value DatabarTruncated
     /// </summary>
     public const DatabarTruncated =  "DatabarTruncated";
+    public const DATABAR_TRUNCATED = "DatabarTruncated";
 
     /// <summary>
     /// Enum value DeutschePostIdentcode
     /// </summary>
     public const DeutschePostIdentcode =  "DeutschePostIdentcode";
+    public const DEUTSCHE_POST_IDENTCODE = "DeutschePostIdentcode";
 
     /// <summary>
     /// Enum value DeutschePostLeitcode
     /// </summary>
     public const DeutschePostLeitcode =  "DeutschePostLeitcode";
+    public const DEUTSCHE_POST_LEITCODE = "DeutschePostLeitcode";
 
     /// <summary>
     /// Enum value DotCode
     /// </summary>
     public const DotCode =  "DotCode";
+    public const DOT_CODE = "DotCode";
 
     /// <summary>
     /// Enum value DutchKIX
     /// </summary>
     public const DutchKIX =  "DutchKIX";
+    public const DUTCH_KIX = "DutchKIX";
 
     /// <summary>
     /// Enum value EAN13
@@ -172,86 +199,103 @@ class DecodeBarcodeType
     /// Enum value GS1Aztec
     /// </summary>
     public const GS1Aztec =  "GS1Aztec";
+    public const GS1_AZTEC = "GS1Aztec";
 
     /// <summary>
     /// Enum value GS1Code128
     /// </summary>
     public const GS1Code128 =  "GS1Code128";
+    public const GS1_CODE128 = "GS1Code128";
 
     /// <summary>
     /// Enum value GS1CompositeBar
     /// </summary>
     public const GS1CompositeBar =  "GS1CompositeBar";
+    public const GS1_COMPOSITE_BAR = "GS1CompositeBar";
 
     /// <summary>
     /// Enum value GS1DataMatrix
     /// </summary>
     public const GS1DataMatrix =  "GS1DataMatrix";
+    public const GS1_DATA_MATRIX = "GS1DataMatrix";
 
     /// <summary>
     /// Enum value GS1DotCode
     /// </summary>
     public const GS1DotCode =  "GS1DotCode";
+    public const GS1_DOT_CODE = "GS1DotCode";
 
     /// <summary>
     /// Enum value GS1HanXin
     /// </summary>
     public const GS1HanXin =  "GS1HanXin";
+    public const GS1_HAN_XIN = "GS1HanXin";
 
     /// <summary>
     /// Enum value GS1MicroPdf417
     /// </summary>
     public const GS1MicroPdf417 =  "GS1MicroPdf417";
+    public const GS1_MICRO_PDF417 = "GS1MicroPdf417";
 
     /// <summary>
     /// Enum value GS1QR
     /// </summary>
     public const GS1QR =  "GS1QR";
+    public const GS1_QR = "GS1QR";
 
     /// <summary>
     /// Enum value HanXin
     /// </summary>
     public const HanXin =  "HanXin";
+    public const HAN_XIN = "HanXin";
 
     /// <summary>
     /// Enum value HIBCAztecLIC
     /// </summary>
     public const HIBCAztecLIC =  "HIBCAztecLIC";
+    public const HIBC_AZTEC_LIC = "HIBCAztecLIC";
 
     /// <summary>
     /// Enum value HIBCAztecPAS
     /// </summary>
     public const HIBCAztecPAS =  "HIBCAztecPAS";
+    public const HIBC_AZTEC_PAS = "HIBCAztecPAS";
 
     /// <summary>
     /// Enum value HIBCCode128LIC
     /// </summary>
     public const HIBCCode128LIC =  "HIBCCode128LIC";
+    public const HIBC_CODE128_LIC = "HIBCCode128LIC";
 
     /// <summary>
     /// Enum value HIBCCode128PAS
     /// </summary>
     public const HIBCCode128PAS =  "HIBCCode128PAS";
+    public const HIBC_CODE128_PAS = "HIBCCode128PAS";
 
     /// <summary>
     /// Enum value HIBCCode39LIC
     /// </summary>
     public const HIBCCode39LIC =  "HIBCCode39LIC";
+    public const HIBC_CODE39_LIC = "HIBCCode39LIC";
 
     /// <summary>
     /// Enum value HIBCCode39PAS
     /// </summary>
     public const HIBCCode39PAS =  "HIBCCode39PAS";
+    public const HIBC_CODE39_PAS = "HIBCCode39PAS";
 
     /// <summary>
     /// Enum value HIBCDataMatrixLIC
     /// </summary>
     public const HIBCDataMatrixLIC =  "HIBCDataMatrixLIC";
+    public const HIBC_DATA_MATRIX_LIC = "HIBCDataMatrixLIC";
 
     /// <summary>
     /// Enum value HIBCDataMatrixPAS
     /// </summary>
     public const HIBCDataMatrixPAS =  "HIBCDataMatrixPAS";
+    public const HIBC_DATA_MATRIX_PAS = "HIBCDataMatrixPAS";
 
     /// <summary>
     /// Enum value HIBCQRLIC
@@ -267,6 +311,7 @@ class DecodeBarcodeType
     /// Enum value IATA2of5
     /// </summary>
     public const IATA2of5 =  "IATA2of5";
+    public const IATA2OF5 = "IATA2of5";
 
     /// <summary>
     /// Enum value ISBN
@@ -297,46 +342,55 @@ class DecodeBarcodeType
     /// Enum value Interleaved2of5
     /// </summary>
     public const Interleaved2of5 =  "Interleaved2of5";
+    public const INTERLEAVED2OF5 = "Interleaved2of5";
 
     /// <summary>
     /// Enum value ItalianPost25
     /// </summary>
     public const ItalianPost25 =  "ItalianPost25";
+    public const ITALIAN_POST25 = "ItalianPost25";
 
     /// <summary>
     /// Enum value MacroPdf417
     /// </summary>
     public const MacroPdf417 =  "MacroPdf417";
+    public const MACRO_PDF417 = "MacroPdf417";
 
     /// <summary>
     /// Enum value Mailmark
     /// </summary>
     public const Mailmark =  "Mailmark";
+    public const MAILMARK = "Mailmark";
 
     /// <summary>
     /// Enum value Matrix2of5
     /// </summary>
     public const Matrix2of5 =  "Matrix2of5";
+    public const MATRIX2OF5 = "Matrix2of5";
 
     /// <summary>
     /// Enum value MaxiCode
     /// </summary>
     public const MaxiCode =  "MaxiCode";
+    public const MAXI_CODE = "MaxiCode";
 
     /// <summary>
     /// Enum value MicrE13B
     /// </summary>
     public const MicrE13B =  "MicrE13B";
+    public const MICR_E13_B = "MicrE13B";
 
     /// <summary>
     /// Enum value MicroPdf417
     /// </summary>
     public const MicroPdf417 =  "MicroPdf417";
+    public const MICRO_PDF417 = "MicroPdf417";
 
     /// <summary>
     /// Enum value MicroQR
     /// </summary>
     public const MicroQR =  "MicroQR";
+    public const MICRO_QR = "MicroQR";
 
     /// <summary>
     /// Enum value MSI
@@ -347,6 +401,7 @@ class DecodeBarcodeType
     /// Enum value OneCode
     /// </summary>
     public const OneCode =  "OneCode";
+    public const ONE_CODE = "OneCode";
 
     /// <summary>
     /// Enum value OPC
@@ -357,26 +412,31 @@ class DecodeBarcodeType
     /// Enum value PatchCode
     /// </summary>
     public const PatchCode =  "PatchCode";
+    public const PATCH_CODE = "PatchCode";
 
     /// <summary>
     /// Enum value Pdf417
     /// </summary>
     public const Pdf417 =  "Pdf417";
+    public const PDF417 = "Pdf417";
 
     /// <summary>
     /// Enum value Pharmacode
     /// </summary>
     public const Pharmacode =  "Pharmacode";
+    public const PHARMACODE = "Pharmacode";
 
     /// <summary>
     /// Enum value Planet
     /// </summary>
     public const Planet =  "Planet";
+    public const PLANET = "Planet";
 
     /// <summary>
     /// Enum value Postnet
     /// </summary>
     public const Postnet =  "Postnet";
+    public const POSTNET = "Postnet";
 
     /// <summary>
     /// Enum value PZN
@@ -387,11 +447,13 @@ class DecodeBarcodeType
     /// Enum value RectMicroQR
     /// </summary>
     public const RectMicroQR =  "RectMicroQR";
+    public const RECT_MICRO_QR = "RectMicroQR";
 
     /// <summary>
     /// Enum value RM4SCC
     /// </summary>
     public const RM4SCC =  "RM4SCC";
+    public const RM4_SCC = "RM4SCC";
 
     /// <summary>
     /// Enum value SCC14
@@ -407,16 +469,19 @@ class DecodeBarcodeType
     /// Enum value Standard2of5
     /// </summary>
     public const Standard2of5 =  "Standard2of5";
+    public const STANDARD2OF5 = "Standard2of5";
 
     /// <summary>
     /// Enum value Supplement
     /// </summary>
     public const Supplement =  "Supplement";
+    public const SUPPLEMENT = "Supplement";
 
     /// <summary>
     /// Enum value SwissPostParcel
     /// </summary>
     public const SwissPostParcel =  "SwissPostParcel";
+    public const SWISS_POST_PARCEL = "SwissPostParcel";
 
     /// <summary>
     /// Enum value UPCA

--- a/src/Aspose/BarCode/Model/ECIEncodings.php
+++ b/src/Aspose/BarCode/Model/ECIEncodings.php
@@ -97,31 +97,37 @@ class ECIEncodings
     /// Enum value Shift_JIS
     /// </summary>
     public const Shift_JIS =  "Shift_JIS";
+    public const SHIFT_JIS = "Shift_JIS";
 
     /// <summary>
     /// Enum value Win1250
     /// </summary>
     public const Win1250 =  "Win1250";
+    public const WIN1250 = "Win1250";
 
     /// <summary>
     /// Enum value Win1251
     /// </summary>
     public const Win1251 =  "Win1251";
+    public const WIN1251 = "Win1251";
 
     /// <summary>
     /// Enum value Win1252
     /// </summary>
     public const Win1252 =  "Win1252";
+    public const WIN1252 = "Win1252";
 
     /// <summary>
     /// Enum value Win1256
     /// </summary>
     public const Win1256 =  "Win1256";
+    public const WIN1256 = "Win1256";
 
     /// <summary>
     /// Enum value UTF16BE
     /// </summary>
     public const UTF16BE =  "UTF16BE";
+    public const UTF16_BE = "UTF16BE";
 
     /// <summary>
     /// Enum value UTF8
@@ -137,6 +143,7 @@ class ECIEncodings
     /// Enum value Big5
     /// </summary>
     public const Big5 =  "Big5";
+    public const BIG5 = "Big5";
 
     /// <summary>
     /// Enum value GB2312
@@ -162,16 +169,19 @@ class ECIEncodings
     /// Enum value UTF16LE
     /// </summary>
     public const UTF16LE =  "UTF16LE";
+    public const UTF16_LE = "UTF16LE";
 
     /// <summary>
     /// Enum value UTF32BE
     /// </summary>
     public const UTF32BE =  "UTF32BE";
+    public const UTF32_BE = "UTF32BE";
 
     /// <summary>
     /// Enum value UTF32LE
     /// </summary>
     public const UTF32LE =  "UTF32LE";
+    public const UTF32_LE = "UTF32LE";
 
     /// <summary>
     /// Enum value INVARIANT

--- a/src/Aspose/BarCode/Model/ECIEncodings.php
+++ b/src/Aspose/BarCode/Model/ECIEncodings.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * ECIEncodings
+ *
+ * @description ECI encoding identifiers. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/eciencodings/
+ */
+class ECIEncodings
+{
+    /// <summary>
+    /// Enum value NONE
+    /// </summary>
+    public const NONE =  "NONE";
+
+    /// <summary>
+    /// Enum value ISO_8859_1
+    /// </summary>
+    public const ISO_8859_1 =  "ISO_8859_1";
+
+    /// <summary>
+    /// Enum value ISO_8859_2
+    /// </summary>
+    public const ISO_8859_2 =  "ISO_8859_2";
+
+    /// <summary>
+    /// Enum value ISO_8859_3
+    /// </summary>
+    public const ISO_8859_3 =  "ISO_8859_3";
+
+    /// <summary>
+    /// Enum value ISO_8859_4
+    /// </summary>
+    public const ISO_8859_4 =  "ISO_8859_4";
+
+    /// <summary>
+    /// Enum value ISO_8859_5
+    /// </summary>
+    public const ISO_8859_5 =  "ISO_8859_5";
+
+    /// <summary>
+    /// Enum value ISO_8859_6
+    /// </summary>
+    public const ISO_8859_6 =  "ISO_8859_6";
+
+    /// <summary>
+    /// Enum value ISO_8859_7
+    /// </summary>
+    public const ISO_8859_7 =  "ISO_8859_7";
+
+    /// <summary>
+    /// Enum value ISO_8859_8
+    /// </summary>
+    public const ISO_8859_8 =  "ISO_8859_8";
+
+    /// <summary>
+    /// Enum value ISO_8859_9
+    /// </summary>
+    public const ISO_8859_9 =  "ISO_8859_9";
+
+    /// <summary>
+    /// Enum value ISO_8859_10
+    /// </summary>
+    public const ISO_8859_10 =  "ISO_8859_10";
+
+    /// <summary>
+    /// Enum value ISO_8859_11
+    /// </summary>
+    public const ISO_8859_11 =  "ISO_8859_11";
+
+    /// <summary>
+    /// Enum value ISO_8859_13
+    /// </summary>
+    public const ISO_8859_13 =  "ISO_8859_13";
+
+    /// <summary>
+    /// Enum value ISO_8859_14
+    /// </summary>
+    public const ISO_8859_14 =  "ISO_8859_14";
+
+    /// <summary>
+    /// Enum value ISO_8859_15
+    /// </summary>
+    public const ISO_8859_15 =  "ISO_8859_15";
+
+    /// <summary>
+    /// Enum value ISO_8859_16
+    /// </summary>
+    public const ISO_8859_16 =  "ISO_8859_16";
+
+    /// <summary>
+    /// Enum value Shift_JIS
+    /// </summary>
+    public const Shift_JIS =  "Shift_JIS";
+
+    /// <summary>
+    /// Enum value Win1250
+    /// </summary>
+    public const Win1250 =  "Win1250";
+
+    /// <summary>
+    /// Enum value Win1251
+    /// </summary>
+    public const Win1251 =  "Win1251";
+
+    /// <summary>
+    /// Enum value Win1252
+    /// </summary>
+    public const Win1252 =  "Win1252";
+
+    /// <summary>
+    /// Enum value Win1256
+    /// </summary>
+    public const Win1256 =  "Win1256";
+
+    /// <summary>
+    /// Enum value UTF16BE
+    /// </summary>
+    public const UTF16BE =  "UTF16BE";
+
+    /// <summary>
+    /// Enum value UTF8
+    /// </summary>
+    public const UTF8 =  "UTF8";
+
+    /// <summary>
+    /// Enum value US_ASCII
+    /// </summary>
+    public const US_ASCII =  "US_ASCII";
+
+    /// <summary>
+    /// Enum value Big5
+    /// </summary>
+    public const Big5 =  "Big5";
+
+    /// <summary>
+    /// Enum value GB2312
+    /// </summary>
+    public const GB2312 =  "GB2312";
+
+    /// <summary>
+    /// Enum value EUC_KR
+    /// </summary>
+    public const EUC_KR =  "EUC_KR";
+
+    /// <summary>
+    /// Enum value GBK
+    /// </summary>
+    public const GBK =  "GBK";
+
+    /// <summary>
+    /// Enum value GB18030
+    /// </summary>
+    public const GB18030 =  "GB18030";
+
+    /// <summary>
+    /// Enum value UTF16LE
+    /// </summary>
+    public const UTF16LE =  "UTF16LE";
+
+    /// <summary>
+    /// Enum value UTF32BE
+    /// </summary>
+    public const UTF32BE =  "UTF32BE";
+
+    /// <summary>
+    /// Enum value UTF32LE
+    /// </summary>
+    public const UTF32LE =  "UTF32LE";
+
+    /// <summary>
+    /// Enum value INVARIANT
+    /// </summary>
+    public const INVARIANT =  "INVARIANT";
+
+    /// <summary>
+    /// Enum value BINARY
+    /// </summary>
+    public const BINARY =  "BINARY";
+
+}

--- a/src/Aspose/BarCode/Model/EncodeBarcodeType.php
+++ b/src/Aspose/BarCode/Model/EncodeBarcodeType.php
@@ -9,7 +9,7 @@ use Aspose\BarCode\ObjectSerializer;
 /**
  * EncodeBarcodeType
  *
- * @description See Aspose.BarCode.Generation.EncodeTypes
+ * @description See https://reference.aspose.com/barcode/net/aspose.barcode.generation/encodetypes/
  */
 class EncodeBarcodeType
 {

--- a/src/Aspose/BarCode/Model/EncodeBarcodeType.php
+++ b/src/Aspose/BarCode/Model/EncodeBarcodeType.php
@@ -22,126 +22,151 @@ class EncodeBarcodeType
     /// Enum value AustraliaPost
     /// </summary>
     public const AustraliaPost =  "AustraliaPost";
+    public const AUSTRALIA_POST = "AustraliaPost";
 
     /// <summary>
     /// Enum value AustralianPosteParcel
     /// </summary>
     public const AustralianPosteParcel =  "AustralianPosteParcel";
+    public const AUSTRALIAN_POSTE_PARCEL = "AustralianPosteParcel";
 
     /// <summary>
     /// Enum value Aztec
     /// </summary>
     public const Aztec =  "Aztec";
+    public const AZTEC = "Aztec";
 
     /// <summary>
     /// Enum value Codabar
     /// </summary>
     public const Codabar =  "Codabar";
+    public const CODABAR = "Codabar";
 
     /// <summary>
     /// Enum value CodablockF
     /// </summary>
     public const CodablockF =  "CodablockF";
+    public const CODABLOCK_F = "CodablockF";
 
     /// <summary>
     /// Enum value Code11
     /// </summary>
     public const Code11 =  "Code11";
+    public const CODE11 = "Code11";
 
     /// <summary>
     /// Enum value Code128
     /// </summary>
     public const Code128 =  "Code128";
+    public const CODE128 = "Code128";
 
     /// <summary>
     /// Enum value Code16K
     /// </summary>
     public const Code16K =  "Code16K";
+    public const CODE16_K = "Code16K";
 
     /// <summary>
     /// Enum value Code32
     /// </summary>
     public const Code32 =  "Code32";
+    public const CODE32 = "Code32";
 
     /// <summary>
     /// Enum value Code39
     /// </summary>
     public const Code39 =  "Code39";
+    public const CODE39 = "Code39";
 
     /// <summary>
     /// Enum value Code39FullASCII
     /// </summary>
     public const Code39FullASCII =  "Code39FullASCII";
+    public const CODE39_FULL_ASCII = "Code39FullASCII";
 
     /// <summary>
     /// Enum value Code93
     /// </summary>
     public const Code93 =  "Code93";
+    public const CODE93 = "Code93";
 
     /// <summary>
     /// Enum value DataLogic2of5
     /// </summary>
     public const DataLogic2of5 =  "DataLogic2of5";
+    public const DATA_LOGIC2OF5 = "DataLogic2of5";
 
     /// <summary>
     /// Enum value DataMatrix
     /// </summary>
     public const DataMatrix =  "DataMatrix";
+    public const DATA_MATRIX = "DataMatrix";
 
     /// <summary>
     /// Enum value DatabarExpanded
     /// </summary>
     public const DatabarExpanded =  "DatabarExpanded";
+    public const DATABAR_EXPANDED = "DatabarExpanded";
 
     /// <summary>
     /// Enum value DatabarExpandedStacked
     /// </summary>
     public const DatabarExpandedStacked =  "DatabarExpandedStacked";
+    public const DATABAR_EXPANDED_STACKED = "DatabarExpandedStacked";
 
     /// <summary>
     /// Enum value DatabarLimited
     /// </summary>
     public const DatabarLimited =  "DatabarLimited";
+    public const DATABAR_LIMITED = "DatabarLimited";
 
     /// <summary>
     /// Enum value DatabarOmniDirectional
     /// </summary>
     public const DatabarOmniDirectional =  "DatabarOmniDirectional";
+    public const DATABAR_OMNI_DIRECTIONAL = "DatabarOmniDirectional";
 
     /// <summary>
     /// Enum value DatabarStacked
     /// </summary>
     public const DatabarStacked =  "DatabarStacked";
+    public const DATABAR_STACKED = "DatabarStacked";
 
     /// <summary>
     /// Enum value DatabarStackedOmniDirectional
     /// </summary>
     public const DatabarStackedOmniDirectional =  "DatabarStackedOmniDirectional";
+    public const DATABAR_STACKED_OMNI_DIRECTIONAL = "DatabarStackedOmniDirectional";
 
     /// <summary>
     /// Enum value DatabarTruncated
     /// </summary>
     public const DatabarTruncated =  "DatabarTruncated";
+    public const DATABAR_TRUNCATED = "DatabarTruncated";
 
     /// <summary>
     /// Enum value DeutschePostIdentcode
     /// </summary>
     public const DeutschePostIdentcode =  "DeutschePostIdentcode";
+    public const DEUTSCHE_POST_IDENTCODE = "DeutschePostIdentcode";
 
     /// <summary>
     /// Enum value DeutschePostLeitcode
     /// </summary>
     public const DeutschePostLeitcode =  "DeutschePostLeitcode";
+    public const DEUTSCHE_POST_LEITCODE = "DeutschePostLeitcode";
 
     /// <summary>
     /// Enum value DotCode
     /// </summary>
     public const DotCode =  "DotCode";
+    public const DOT_CODE = "DotCode";
 
     /// <summary>
     /// Enum value DutchKIX
     /// </summary>
     public const DutchKIX =  "DutchKIX";
+    public const DUTCH_KIX = "DutchKIX";
 
     /// <summary>
     /// Enum value EAN13
@@ -162,51 +187,61 @@ class EncodeBarcodeType
     /// Enum value GS1Aztec
     /// </summary>
     public const GS1Aztec =  "GS1Aztec";
+    public const GS1_AZTEC = "GS1Aztec";
 
     /// <summary>
     /// Enum value GS1CodablockF
     /// </summary>
     public const GS1CodablockF =  "GS1CodablockF";
+    public const GS1_CODABLOCK_F = "GS1CodablockF";
 
     /// <summary>
     /// Enum value GS1Code128
     /// </summary>
     public const GS1Code128 =  "GS1Code128";
+    public const GS1_CODE128 = "GS1Code128";
 
     /// <summary>
     /// Enum value GS1DataMatrix
     /// </summary>
     public const GS1DataMatrix =  "GS1DataMatrix";
+    public const GS1_DATA_MATRIX = "GS1DataMatrix";
 
     /// <summary>
     /// Enum value GS1DotCode
     /// </summary>
     public const GS1DotCode =  "GS1DotCode";
+    public const GS1_DOT_CODE = "GS1DotCode";
 
     /// <summary>
     /// Enum value GS1HanXin
     /// </summary>
     public const GS1HanXin =  "GS1HanXin";
+    public const GS1_HAN_XIN = "GS1HanXin";
 
     /// <summary>
     /// Enum value GS1MicroPdf417
     /// </summary>
     public const GS1MicroPdf417 =  "GS1MicroPdf417";
+    public const GS1_MICRO_PDF417 = "GS1MicroPdf417";
 
     /// <summary>
     /// Enum value GS1QR
     /// </summary>
     public const GS1QR =  "GS1QR";
+    public const GS1_QR = "GS1QR";
 
     /// <summary>
     /// Enum value HanXin
     /// </summary>
     public const HanXin =  "HanXin";
+    public const HAN_XIN = "HanXin";
 
     /// <summary>
     /// Enum value IATA2of5
     /// </summary>
     public const IATA2of5 =  "IATA2of5";
+    public const IATA2OF5 = "IATA2of5";
 
     /// <summary>
     /// Enum value ISBN
@@ -237,11 +272,13 @@ class EncodeBarcodeType
     /// Enum value Interleaved2of5
     /// </summary>
     public const Interleaved2of5 =  "Interleaved2of5";
+    public const INTERLEAVED2OF5 = "Interleaved2of5";
 
     /// <summary>
     /// Enum value ItalianPost25
     /// </summary>
     public const ItalianPost25 =  "ItalianPost25";
+    public const ITALIAN_POST25 = "ItalianPost25";
 
     /// <summary>
     /// Enum value MSI
@@ -252,31 +289,37 @@ class EncodeBarcodeType
     /// Enum value MacroPdf417
     /// </summary>
     public const MacroPdf417 =  "MacroPdf417";
+    public const MACRO_PDF417 = "MacroPdf417";
 
     /// <summary>
     /// Enum value Mailmark
     /// </summary>
     public const Mailmark =  "Mailmark";
+    public const MAILMARK = "Mailmark";
 
     /// <summary>
     /// Enum value Matrix2of5
     /// </summary>
     public const Matrix2of5 =  "Matrix2of5";
+    public const MATRIX2OF5 = "Matrix2of5";
 
     /// <summary>
     /// Enum value MaxiCode
     /// </summary>
     public const MaxiCode =  "MaxiCode";
+    public const MAXI_CODE = "MaxiCode";
 
     /// <summary>
     /// Enum value MicroPdf417
     /// </summary>
     public const MicroPdf417 =  "MicroPdf417";
+    public const MICRO_PDF417 = "MicroPdf417";
 
     /// <summary>
     /// Enum value MicroQR
     /// </summary>
     public const MicroQR =  "MicroQR";
+    public const MICRO_QR = "MicroQR";
 
     /// <summary>
     /// Enum value OPC
@@ -287,6 +330,7 @@ class EncodeBarcodeType
     /// Enum value OneCode
     /// </summary>
     public const OneCode =  "OneCode";
+    public const ONE_CODE = "OneCode";
 
     /// <summary>
     /// Enum value PZN
@@ -297,36 +341,43 @@ class EncodeBarcodeType
     /// Enum value PatchCode
     /// </summary>
     public const PatchCode =  "PatchCode";
+    public const PATCH_CODE = "PatchCode";
 
     /// <summary>
     /// Enum value Pdf417
     /// </summary>
     public const Pdf417 =  "Pdf417";
+    public const PDF417 = "Pdf417";
 
     /// <summary>
     /// Enum value Pharmacode
     /// </summary>
     public const Pharmacode =  "Pharmacode";
+    public const PHARMACODE = "Pharmacode";
 
     /// <summary>
     /// Enum value Planet
     /// </summary>
     public const Planet =  "Planet";
+    public const PLANET = "Planet";
 
     /// <summary>
     /// Enum value Postnet
     /// </summary>
     public const Postnet =  "Postnet";
+    public const POSTNET = "Postnet";
 
     /// <summary>
     /// Enum value RM4SCC
     /// </summary>
     public const RM4SCC =  "RM4SCC";
+    public const RM4_SCC = "RM4SCC";
 
     /// <summary>
     /// Enum value RectMicroQR
     /// </summary>
     public const RectMicroQR =  "RectMicroQR";
+    public const RECT_MICRO_QR = "RectMicroQR";
 
     /// <summary>
     /// Enum value SCC14
@@ -342,16 +393,19 @@ class EncodeBarcodeType
     /// Enum value SingaporePost
     /// </summary>
     public const SingaporePost =  "SingaporePost";
+    public const SINGAPORE_POST = "SingaporePost";
 
     /// <summary>
     /// Enum value Standard2of5
     /// </summary>
     public const Standard2of5 =  "Standard2of5";
+    public const STANDARD2OF5 = "Standard2of5";
 
     /// <summary>
     /// Enum value SwissPostParcel
     /// </summary>
     public const SwissPostParcel =  "SwissPostParcel";
+    public const SWISS_POST_PARCEL = "SwissPostParcel";
 
     /// <summary>
     /// Enum value UPCA
@@ -367,11 +421,13 @@ class EncodeBarcodeType
     /// Enum value UpcaGs1Code128Coupon
     /// </summary>
     public const UpcaGs1Code128Coupon =  "UpcaGs1Code128Coupon";
+    public const UPCA_GS1_CODE128_COUPON = "UpcaGs1Code128Coupon";
 
     /// <summary>
     /// Enum value UpcaGs1DatabarCoupon
     /// </summary>
     public const UpcaGs1DatabarCoupon =  "UpcaGs1DatabarCoupon";
+    public const UPCA_GS1_DATABAR_COUPON = "UpcaGs1DatabarCoupon";
 
     /// <summary>
     /// Enum value VIN

--- a/src/Aspose/BarCode/Model/EncodeData.php
+++ b/src/Aspose/BarCode/Model/EncodeData.php
@@ -154,7 +154,7 @@ class EncodeData implements ArrayAccess
      */
     public function __construct(?array $data = null)
     {
-        $this->container['data_type'] = isset($data['data_type']) ? $data['data_type'] : null;
+        $this->container['data_type'] = isset($data['data_type']) ? $data['data_type'] : EncodeDataType::STRING_DATA;
         $this->container['data'] = isset($data['data']) ? $data['data'] : null;
     }
 
@@ -208,7 +208,7 @@ class EncodeData implements ArrayAccess
     /**
      * Sets data_type
      *
-     * @param \Aspose\BarCode\Model\EncodeDataType $data_type data_type
+     * @param \Aspose\BarCode\Model\EncodeDataType $data_type Type of data to encode. Default value: StringData.
      *
      * @return $this
      */
@@ -251,7 +251,7 @@ class EncodeData implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -263,7 +263,7 @@ class EncodeData implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -276,8 +276,8 @@ class EncodeData implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -293,7 +293,7 @@ class EncodeData implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/EncodeData.php
+++ b/src/Aspose/BarCode/Model/EncodeData.php
@@ -10,7 +10,7 @@ use Aspose\BarCode\ObjectSerializer;
 /**
  * EncodeData
  *
- * @description Data to encode in barcode
+ * @description Data to encode in a barcode.
  */
 class EncodeData implements ArrayAccess
 {
@@ -232,7 +232,7 @@ class EncodeData implements ArrayAccess
     /**
      * Sets data
      *
-     * @param string $data String represents data to encode
+     * @param string $data String that represents the data to encode.
      *
      * @return $this
      */

--- a/src/Aspose/BarCode/Model/EncodeDataType.php
+++ b/src/Aspose/BarCode/Model/EncodeDataType.php
@@ -9,7 +9,7 @@ use Aspose\BarCode\ObjectSerializer;
 /**
  * EncodeDataType
  *
- * @description Types of data can be encoded to barcode
+ * @description Types of data that can be encoded into a barcode.
  */
 class EncodeDataType
 {

--- a/src/Aspose/BarCode/Model/EncodeDataType.php
+++ b/src/Aspose/BarCode/Model/EncodeDataType.php
@@ -17,15 +17,18 @@ class EncodeDataType
     /// Enum value StringData
     /// </summary>
     public const StringData =  "StringData";
+    public const STRING_DATA = "StringData";
 
     /// <summary>
     /// Enum value Base64Bytes
     /// </summary>
     public const Base64Bytes =  "Base64Bytes";
+    public const BASE64_BYTES = "Base64Bytes";
 
     /// <summary>
     /// Enum value HexBytes
     /// </summary>
     public const HexBytes =  "HexBytes";
+    public const HEX_BYTES = "HexBytes";
 
 }

--- a/src/Aspose/BarCode/Model/GenerateParams.php
+++ b/src/Aspose/BarCode/Model/GenerateParams.php
@@ -231,7 +231,7 @@ class GenerateParams implements ArrayAccess
     /**
      * Sets barcode_type
      *
-     * @param \Aspose\BarCode\Model\EncodeBarcodeType $barcode_type barcode_type
+     * @param \Aspose\BarCode\Model\EncodeBarcodeType $barcode_type Barcode type.
      *
      * @return $this
      */
@@ -255,7 +255,7 @@ class GenerateParams implements ArrayAccess
     /**
      * Sets encode_data
      *
-     * @param \Aspose\BarCode\Model\EncodeData $encode_data encode_data
+     * @param \Aspose\BarCode\Model\EncodeData $encode_data Data to encode into a barcode.
      *
      * @return $this
      */
@@ -279,7 +279,7 @@ class GenerateParams implements ArrayAccess
     /**
      * Sets barcode_image_params
      *
-     * @param \Aspose\BarCode\Model\BarcodeImageParams $barcode_image_params barcode_image_params
+     * @param \Aspose\BarCode\Model\BarcodeImageParams $barcode_image_params Optional barcode image parameters.
      *
      * @return $this
      */
@@ -303,7 +303,7 @@ class GenerateParams implements ArrayAccess
     /**
      * Sets qr_params
      *
-     * @param \Aspose\BarCode\Model\QrParams $qr_params qr_params
+     * @param \Aspose\BarCode\Model\QrParams $qr_params Optional QR barcode generation parameters.
      *
      * @return $this
      */
@@ -327,7 +327,7 @@ class GenerateParams implements ArrayAccess
     /**
      * Sets code128_params
      *
-     * @param \Aspose\BarCode\Model\Code128Params $code128_params code128_params
+     * @param \Aspose\BarCode\Model\Code128Params $code128_params Optional Code128 barcode generation parameters.
      *
      * @return $this
      */
@@ -351,7 +351,7 @@ class GenerateParams implements ArrayAccess
     /**
      * Sets pdf417_params
      *
-     * @param \Aspose\BarCode\Model\Pdf417Params $pdf417_params pdf417_params
+     * @param \Aspose\BarCode\Model\Pdf417Params $pdf417_params Optional PDF417 barcode generation parameters.
      *
      * @return $this
      */
@@ -365,7 +365,7 @@ class GenerateParams implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -377,7 +377,7 @@ class GenerateParams implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -390,8 +390,8 @@ class GenerateParams implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -407,7 +407,7 @@ class GenerateParams implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/GenerateParams.php
+++ b/src/Aspose/BarCode/Model/GenerateParams.php
@@ -10,7 +10,7 @@ use Aspose\BarCode\ObjectSerializer;
 /**
  * GenerateParams
  *
- * @description Barcode generation parameters
+ * @description Barcode generation parameters.
  */
 class GenerateParams implements ArrayAccess
 {
@@ -31,7 +31,10 @@ class GenerateParams implements ArrayAccess
     protected static array $swaggerTypes = [
         'barcode_type' => '\Aspose\BarCode\Model\EncodeBarcodeType',
         'encode_data' => '\Aspose\BarCode\Model\EncodeData',
-        'barcode_image_params' => '\Aspose\BarCode\Model\BarcodeImageParams'
+        'barcode_image_params' => '\Aspose\BarCode\Model\BarcodeImageParams',
+        'qr_params' => '\Aspose\BarCode\Model\QrParams',
+        'code128_params' => '\Aspose\BarCode\Model\Code128Params',
+        'pdf417_params' => '\Aspose\BarCode\Model\Pdf417Params'
     ];
 
     /**
@@ -42,7 +45,10 @@ class GenerateParams implements ArrayAccess
     protected static array $swaggerFormats = [
         'barcode_type' => null,
         'encode_data' => null,
-        'barcode_image_params' => null
+        'barcode_image_params' => null,
+        'qr_params' => null,
+        'code128_params' => null,
+        'pdf417_params' => null
     ];
 
     /**
@@ -74,7 +80,10 @@ class GenerateParams implements ArrayAccess
     protected static $attributeMap = [
         'barcode_type' => 'barcodeType',
         'encode_data' => 'encodeData',
-        'barcode_image_params' => 'barcodeImageParams'
+        'barcode_image_params' => 'barcodeImageParams',
+        'qr_params' => 'qrParams',
+        'code128_params' => 'code128Params',
+        'pdf417_params' => 'pdf417Params'
     ];
 
     /**
@@ -85,7 +94,10 @@ class GenerateParams implements ArrayAccess
     protected static $setters = [
         'barcode_type' => 'setBarcodeType',
         'encode_data' => 'setEncodeData',
-        'barcode_image_params' => 'setBarcodeImageParams'
+        'barcode_image_params' => 'setBarcodeImageParams',
+        'qr_params' => 'setQrParams',
+        'code128_params' => 'setCode128Params',
+        'pdf417_params' => 'setPdf417Params'
     ];
 
     /**
@@ -96,7 +108,10 @@ class GenerateParams implements ArrayAccess
     protected static $getters = [
         'barcode_type' => 'getBarcodeType',
         'encode_data' => 'getEncodeData',
-        'barcode_image_params' => 'getBarcodeImageParams'
+        'barcode_image_params' => 'getBarcodeImageParams',
+        'qr_params' => 'getQrParams',
+        'code128_params' => 'getCode128Params',
+        'pdf417_params' => 'getPdf417Params'
     ];
 
     /**
@@ -162,6 +177,9 @@ class GenerateParams implements ArrayAccess
         $this->container['barcode_type'] = isset($data['barcode_type']) ? $data['barcode_type'] : null;
         $this->container['encode_data'] = isset($data['encode_data']) ? $data['encode_data'] : null;
         $this->container['barcode_image_params'] = isset($data['barcode_image_params']) ? $data['barcode_image_params'] : null;
+        $this->container['qr_params'] = isset($data['qr_params']) ? $data['qr_params'] : null;
+        $this->container['code128_params'] = isset($data['code128_params']) ? $data['code128_params'] : null;
+        $this->container['pdf417_params'] = isset($data['pdf417_params']) ? $data['pdf417_params'] : null;
     }
 
     /**
@@ -268,6 +286,78 @@ class GenerateParams implements ArrayAccess
     public function setBarcodeImageParams($barcode_image_params)
     {
         $this->container['barcode_image_params'] = $barcode_image_params;
+
+        return $this;
+    }
+
+    /**
+     * Gets qr_params
+     *
+     * @return \Aspose\BarCode\Model\QrParams
+     */
+    public function getQrParams()
+    {
+        return $this->container['qr_params'];
+    }
+
+    /**
+     * Sets qr_params
+     *
+     * @param \Aspose\BarCode\Model\QrParams $qr_params qr_params
+     *
+     * @return $this
+     */
+    public function setQrParams($qr_params)
+    {
+        $this->container['qr_params'] = $qr_params;
+
+        return $this;
+    }
+
+    /**
+     * Gets code128_params
+     *
+     * @return \Aspose\BarCode\Model\Code128Params
+     */
+    public function getCode128Params()
+    {
+        return $this->container['code128_params'];
+    }
+
+    /**
+     * Sets code128_params
+     *
+     * @param \Aspose\BarCode\Model\Code128Params $code128_params code128_params
+     *
+     * @return $this
+     */
+    public function setCode128Params($code128_params)
+    {
+        $this->container['code128_params'] = $code128_params;
+
+        return $this;
+    }
+
+    /**
+     * Gets pdf417_params
+     *
+     * @return \Aspose\BarCode\Model\Pdf417Params
+     */
+    public function getPdf417Params()
+    {
+        return $this->container['pdf417_params'];
+    }
+
+    /**
+     * Sets pdf417_params
+     *
+     * @param \Aspose\BarCode\Model\Pdf417Params $pdf417_params pdf417_params
+     *
+     * @return $this
+     */
+    public function setPdf417Params($pdf417_params)
+    {
+        $this->container['pdf417_params'] = $pdf417_params;
 
         return $this;
     }

--- a/src/Aspose/BarCode/Model/GraphicsUnit.php
+++ b/src/Aspose/BarCode/Model/GraphicsUnit.php
@@ -17,20 +17,24 @@ class GraphicsUnit
     /// Enum value Pixel
     /// </summary>
     public const Pixel =  "Pixel";
+    public const PIXEL = "Pixel";
 
     /// <summary>
     /// Enum value Point
     /// </summary>
     public const Point =  "Point";
+    public const POINT = "Point";
 
     /// <summary>
     /// Enum value Inch
     /// </summary>
     public const Inch =  "Inch";
+    public const INCH = "Inch";
 
     /// <summary>
     /// Enum value Millimeter
     /// </summary>
     public const Millimeter =  "Millimeter";
+    public const MILLIMETER = "Millimeter";
 
 }

--- a/src/Aspose/BarCode/Model/GraphicsUnit.php
+++ b/src/Aspose/BarCode/Model/GraphicsUnit.php
@@ -9,7 +9,7 @@ use Aspose\BarCode\ObjectSerializer;
 /**
  * GraphicsUnit
  *
- * @description Subset of Aspose.Drawing.GraphicsUnit.
+ * @description Subset of https://reference.aspose.com/drawing/net/system.drawing/graphicsunit/
  */
 class GraphicsUnit
 {

--- a/src/Aspose/BarCode/Model/MacroCharacter.php
+++ b/src/Aspose/BarCode/Model/MacroCharacter.php
@@ -17,15 +17,18 @@ class MacroCharacter
     /// Enum value None
     /// </summary>
     public const None =  "None";
+    public const NONE = "None";
 
     /// <summary>
     /// Enum value Macro05
     /// </summary>
     public const Macro05 =  "Macro05";
+    public const MACRO05 = "Macro05";
 
     /// <summary>
     /// Enum value Macro06
     /// </summary>
     public const Macro06 =  "Macro06";
+    public const MACRO06 = "Macro06";
 
 }

--- a/src/Aspose/BarCode/Model/MacroCharacter.php
+++ b/src/Aspose/BarCode/Model/MacroCharacter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * MacroCharacter
+ *
+ * @description PDF417 macro character mode. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/macrocharacter/
+ */
+class MacroCharacter
+{
+    /// <summary>
+    /// Enum value None
+    /// </summary>
+    public const None =  "None";
+
+    /// <summary>
+    /// Enum value Macro05
+    /// </summary>
+    public const Macro05 =  "Macro05";
+
+    /// <summary>
+    /// Enum value Macro06
+    /// </summary>
+    public const Macro06 =  "Macro06";
+
+}

--- a/src/Aspose/BarCode/Model/MicroQRVersion.php
+++ b/src/Aspose/BarCode/Model/MicroQRVersion.php
@@ -17,6 +17,7 @@ class MicroQRVersion
     /// Enum value Auto
     /// </summary>
     public const Auto =  "Auto";
+    public const AUTO = "Auto";
 
     /// <summary>
     /// Enum value M1

--- a/src/Aspose/BarCode/Model/MicroQRVersion.php
+++ b/src/Aspose/BarCode/Model/MicroQRVersion.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * MicroQRVersion
+ *
+ * @description MicroQR barcode version. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/microqrversion/
+ */
+class MicroQRVersion
+{
+    /// <summary>
+    /// Enum value Auto
+    /// </summary>
+    public const Auto =  "Auto";
+
+    /// <summary>
+    /// Enum value M1
+    /// </summary>
+    public const M1 =  "M1";
+
+    /// <summary>
+    /// Enum value M2
+    /// </summary>
+    public const M2 =  "M2";
+
+    /// <summary>
+    /// Enum value M3
+    /// </summary>
+    public const M3 =  "M3";
+
+    /// <summary>
+    /// Enum value M4
+    /// </summary>
+    public const M4 =  "M4";
+
+}

--- a/src/Aspose/BarCode/Model/Pdf417EncodeMode.php
+++ b/src/Aspose/BarCode/Model/Pdf417EncodeMode.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * Pdf417EncodeMode
+ *
+ * @description PDF417 barcode encode mode. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/pdf417encodemode/
+ */
+class Pdf417EncodeMode
+{
+    /// <summary>
+    /// Enum value Auto
+    /// </summary>
+    public const Auto =  "Auto";
+
+    /// <summary>
+    /// Enum value Binary
+    /// </summary>
+    public const Binary =  "Binary";
+
+    /// <summary>
+    /// Enum value ECI
+    /// </summary>
+    public const ECI =  "ECI";
+
+    /// <summary>
+    /// Enum value Extended
+    /// </summary>
+    public const Extended =  "Extended";
+
+}

--- a/src/Aspose/BarCode/Model/Pdf417EncodeMode.php
+++ b/src/Aspose/BarCode/Model/Pdf417EncodeMode.php
@@ -17,11 +17,13 @@ class Pdf417EncodeMode
     /// Enum value Auto
     /// </summary>
     public const Auto =  "Auto";
+    public const AUTO = "Auto";
 
     /// <summary>
     /// Enum value Binary
     /// </summary>
     public const Binary =  "Binary";
+    public const BINARY = "Binary";
 
     /// <summary>
     /// Enum value ECI
@@ -32,5 +34,6 @@ class Pdf417EncodeMode
     /// Enum value Extended
     /// </summary>
     public const Extended =  "Extended";
+    public const EXTENDED = "Extended";
 
 }

--- a/src/Aspose/BarCode/Model/Pdf417ErrorLevel.php
+++ b/src/Aspose/BarCode/Model/Pdf417ErrorLevel.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * Pdf417ErrorLevel
+ *
+ * @description PDF417 barcode error correction level. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/pdf417errorlevel/
+ */
+class Pdf417ErrorLevel
+{
+    /// <summary>
+    /// Enum value Level0
+    /// </summary>
+    public const Level0 =  "Level0";
+
+    /// <summary>
+    /// Enum value Level1
+    /// </summary>
+    public const Level1 =  "Level1";
+
+    /// <summary>
+    /// Enum value Level2
+    /// </summary>
+    public const Level2 =  "Level2";
+
+    /// <summary>
+    /// Enum value Level3
+    /// </summary>
+    public const Level3 =  "Level3";
+
+    /// <summary>
+    /// Enum value Level4
+    /// </summary>
+    public const Level4 =  "Level4";
+
+    /// <summary>
+    /// Enum value Level5
+    /// </summary>
+    public const Level5 =  "Level5";
+
+    /// <summary>
+    /// Enum value Level6
+    /// </summary>
+    public const Level6 =  "Level6";
+
+    /// <summary>
+    /// Enum value Level7
+    /// </summary>
+    public const Level7 =  "Level7";
+
+    /// <summary>
+    /// Enum value Level8
+    /// </summary>
+    public const Level8 =  "Level8";
+
+}

--- a/src/Aspose/BarCode/Model/Pdf417ErrorLevel.php
+++ b/src/Aspose/BarCode/Model/Pdf417ErrorLevel.php
@@ -17,45 +17,54 @@ class Pdf417ErrorLevel
     /// Enum value Level0
     /// </summary>
     public const Level0 =  "Level0";
+    public const LEVEL0 = "Level0";
 
     /// <summary>
     /// Enum value Level1
     /// </summary>
     public const Level1 =  "Level1";
+    public const LEVEL1 = "Level1";
 
     /// <summary>
     /// Enum value Level2
     /// </summary>
     public const Level2 =  "Level2";
+    public const LEVEL2 = "Level2";
 
     /// <summary>
     /// Enum value Level3
     /// </summary>
     public const Level3 =  "Level3";
+    public const LEVEL3 = "Level3";
 
     /// <summary>
     /// Enum value Level4
     /// </summary>
     public const Level4 =  "Level4";
+    public const LEVEL4 = "Level4";
 
     /// <summary>
     /// Enum value Level5
     /// </summary>
     public const Level5 =  "Level5";
+    public const LEVEL5 = "Level5";
 
     /// <summary>
     /// Enum value Level6
     /// </summary>
     public const Level6 =  "Level6";
+    public const LEVEL6 = "Level6";
 
     /// <summary>
     /// Enum value Level7
     /// </summary>
     public const Level7 =  "Level7";
+    public const LEVEL7 = "Level7";
 
     /// <summary>
     /// Enum value Level8
     /// </summary>
     public const Level8 =  "Level8";
+    public const LEVEL8 = "Level8";
 
 }

--- a/src/Aspose/BarCode/Model/Pdf417Params.php
+++ b/src/Aspose/BarCode/Model/Pdf417Params.php
@@ -291,7 +291,7 @@ class Pdf417Params implements ArrayAccess
     /**
      * Sets pdf417_encode_mode
      *
-     * @param \Aspose\BarCode\Model\Pdf417EncodeMode $pdf417_encode_mode pdf417_encode_mode
+     * @param \Aspose\BarCode\Model\Pdf417EncodeMode $pdf417_encode_mode PDF417 barcode encode mode.
      *
      * @return $this
      */
@@ -315,7 +315,7 @@ class Pdf417Params implements ArrayAccess
     /**
      * Sets pdf417_error_level
      *
-     * @param \Aspose\BarCode\Model\Pdf417ErrorLevel $pdf417_error_level pdf417_error_level
+     * @param \Aspose\BarCode\Model\Pdf417ErrorLevel $pdf417_error_level PDF417 barcode error correction level.
      *
      * @return $this
      */
@@ -459,7 +459,7 @@ class Pdf417Params implements ArrayAccess
     /**
      * Sets pdf417_eci_encoding
      *
-     * @param \Aspose\BarCode\Model\ECIEncodings $pdf417_eci_encoding pdf417_eci_encoding
+     * @param \Aspose\BarCode\Model\ECIEncodings $pdf417_eci_encoding ECI encoding for PDF417 barcode data.
      *
      * @return $this
      */
@@ -507,7 +507,7 @@ class Pdf417Params implements ArrayAccess
     /**
      * Sets pdf417_macro_characters
      *
-     * @param \Aspose\BarCode\Model\MacroCharacter $pdf417_macro_characters pdf417_macro_characters
+     * @param \Aspose\BarCode\Model\MacroCharacter $pdf417_macro_characters Macro character to prepend (structured append).
      *
      * @return $this
      */
@@ -569,7 +569,7 @@ class Pdf417Params implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -581,7 +581,7 @@ class Pdf417Params implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -594,8 +594,8 @@ class Pdf417Params implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -611,7 +611,7 @@ class Pdf417Params implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/Pdf417Params.php
+++ b/src/Aspose/BarCode/Model/Pdf417Params.php
@@ -1,0 +1,639 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use ArrayAccess;
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * Pdf417Params
+ *
+ * @description Optional PDF417 barcode generation parameters. Applies to Pdf417, MacroPdf417, MicroPdf417, and GS1MicroPdf417 barcode types.
+ */
+class Pdf417Params implements ArrayAccess
+{
+    public const DISCRIMINATOR = null;
+
+    /**
+     * The original name of the model.
+     *
+     * @var string
+     */
+    protected static string $swaggerModelName = "Pdf417Params";
+
+    /**
+     * Array of property to type mappings. Used for (de)serialization
+     *
+     * @var string[]
+     */
+    protected static array $swaggerTypes = [
+        'pdf417_encode_mode' => '\Aspose\BarCode\Model\Pdf417EncodeMode',
+        'pdf417_error_level' => '\Aspose\BarCode\Model\Pdf417ErrorLevel',
+        'pdf417_truncate' => 'bool',
+        'pdf417_columns' => 'int',
+        'pdf417_rows' => 'int',
+        'pdf417_aspect_ratio' => 'float',
+        'pdf417_eci_encoding' => '\Aspose\BarCode\Model\ECIEncodings',
+        'pdf417_is_reader_initialization' => 'bool',
+        'pdf417_macro_characters' => '\Aspose\BarCode\Model\MacroCharacter',
+        'pdf417_is_linked' => 'bool',
+        'pdf417_is_code128_emulation' => 'bool'
+    ];
+
+    /**
+     * Array of property to format mappings. Used for (de)serialization
+     *
+     * @var (string|null)[]
+     */
+    protected static array $swaggerFormats = [
+        'pdf417_encode_mode' => null,
+        'pdf417_error_level' => null,
+        'pdf417_truncate' => null,
+        'pdf417_columns' => 'int32',
+        'pdf417_rows' => 'int32',
+        'pdf417_aspect_ratio' => 'float',
+        'pdf417_eci_encoding' => null,
+        'pdf417_is_reader_initialization' => null,
+        'pdf417_macro_characters' => null,
+        'pdf417_is_linked' => null,
+        'pdf417_is_code128_emulation' => null
+    ];
+
+    /**
+     * Array of property to type mappings. Used for (de)serialization
+     *
+     * @return array
+     */
+    public static function swaggerTypes()
+    {
+        return self::$swaggerTypes;
+    }
+
+    /**
+     * Array of property to format mappings. Used for (de)serialization
+     *
+     * @return array
+     */
+    public static function swaggerFormats()
+    {
+        return self::$swaggerFormats;
+    }
+
+    /**
+     * Array of attributes where the key is the local name,
+     * and the value is the original name
+     *
+     * @var string[]
+     */
+    protected static $attributeMap = [
+        'pdf417_encode_mode' => 'pdf417EncodeMode',
+        'pdf417_error_level' => 'pdf417ErrorLevel',
+        'pdf417_truncate' => 'pdf417Truncate',
+        'pdf417_columns' => 'pdf417Columns',
+        'pdf417_rows' => 'pdf417Rows',
+        'pdf417_aspect_ratio' => 'pdf417AspectRatio',
+        'pdf417_eci_encoding' => 'pdf417ECIEncoding',
+        'pdf417_is_reader_initialization' => 'pdf417IsReaderInitialization',
+        'pdf417_macro_characters' => 'pdf417MacroCharacters',
+        'pdf417_is_linked' => 'pdf417IsLinked',
+        'pdf417_is_code128_emulation' => 'pdf417IsCode128Emulation'
+    ];
+
+    /**
+     * Array of attributes to setter functions (for deserialization of responses)
+     *
+     * @var string[]
+     */
+    protected static $setters = [
+        'pdf417_encode_mode' => 'setPdf417EncodeMode',
+        'pdf417_error_level' => 'setPdf417ErrorLevel',
+        'pdf417_truncate' => 'setPdf417Truncate',
+        'pdf417_columns' => 'setPdf417Columns',
+        'pdf417_rows' => 'setPdf417Rows',
+        'pdf417_aspect_ratio' => 'setPdf417AspectRatio',
+        'pdf417_eci_encoding' => 'setPdf417EciEncoding',
+        'pdf417_is_reader_initialization' => 'setPdf417IsReaderInitialization',
+        'pdf417_macro_characters' => 'setPdf417MacroCharacters',
+        'pdf417_is_linked' => 'setPdf417IsLinked',
+        'pdf417_is_code128_emulation' => 'setPdf417IsCode128Emulation'
+    ];
+
+    /**
+     * Array of attributes to getter functions (for serialization of requests)
+     *
+     * @var string[]
+     */
+    protected static $getters = [
+        'pdf417_encode_mode' => 'getPdf417EncodeMode',
+        'pdf417_error_level' => 'getPdf417ErrorLevel',
+        'pdf417_truncate' => 'getPdf417Truncate',
+        'pdf417_columns' => 'getPdf417Columns',
+        'pdf417_rows' => 'getPdf417Rows',
+        'pdf417_aspect_ratio' => 'getPdf417AspectRatio',
+        'pdf417_eci_encoding' => 'getPdf417EciEncoding',
+        'pdf417_is_reader_initialization' => 'getPdf417IsReaderInitialization',
+        'pdf417_macro_characters' => 'getPdf417MacroCharacters',
+        'pdf417_is_linked' => 'getPdf417IsLinked',
+        'pdf417_is_code128_emulation' => 'getPdf417IsCode128Emulation'
+    ];
+
+    /**
+     * Array of attributes where the key is the local name,
+     * and the value is the original name
+     *
+     * @return array
+     */
+    public static function attributeMap()
+    {
+        return self::$attributeMap;
+    }
+
+    /**
+     * Array of attributes to setter functions (for deserialization of responses)
+     *
+     * @return array
+     */
+    public static function setters()
+    {
+        return self::$setters;
+    }
+
+    /**
+     * Array of attributes to getter functions (for serialization of requests)
+     *
+     * @return array
+     */
+    public static function getters()
+    {
+        return self::$getters;
+    }
+
+    /**
+     * The original name of the model.
+     *
+     * @return string
+     */
+    public function getModelName()
+    {
+        return self::$swaggerModelName;
+    }
+
+
+
+
+
+    /**
+     * Associative array for storing property values
+     *
+     * @var mixed[]
+     */
+    protected $container = [];
+
+    /**
+     * Constructor
+     *
+     * @param mixed[] $data Associated array of property values
+     *                      initializing the model
+     */
+    public function __construct(?array $data = null)
+    {
+        $this->container['pdf417_encode_mode'] = isset($data['pdf417_encode_mode']) ? $data['pdf417_encode_mode'] : null;
+        $this->container['pdf417_error_level'] = isset($data['pdf417_error_level']) ? $data['pdf417_error_level'] : null;
+        $this->container['pdf417_truncate'] = isset($data['pdf417_truncate']) ? $data['pdf417_truncate'] : null;
+        $this->container['pdf417_columns'] = isset($data['pdf417_columns']) ? $data['pdf417_columns'] : null;
+        $this->container['pdf417_rows'] = isset($data['pdf417_rows']) ? $data['pdf417_rows'] : null;
+        $this->container['pdf417_aspect_ratio'] = isset($data['pdf417_aspect_ratio']) ? $data['pdf417_aspect_ratio'] : null;
+        $this->container['pdf417_eci_encoding'] = isset($data['pdf417_eci_encoding']) ? $data['pdf417_eci_encoding'] : null;
+        $this->container['pdf417_is_reader_initialization'] = isset($data['pdf417_is_reader_initialization']) ? $data['pdf417_is_reader_initialization'] : null;
+        $this->container['pdf417_macro_characters'] = isset($data['pdf417_macro_characters']) ? $data['pdf417_macro_characters'] : null;
+        $this->container['pdf417_is_linked'] = isset($data['pdf417_is_linked']) ? $data['pdf417_is_linked'] : null;
+        $this->container['pdf417_is_code128_emulation'] = isset($data['pdf417_is_code128_emulation']) ? $data['pdf417_is_code128_emulation'] : null;
+    }
+
+    /**
+     * Show all the invalid properties with reasons.
+     *
+     * @return array invalid properties with reasons
+     */
+    public function listInvalidProperties()
+    {
+        $invalidProperties = [];
+
+        if (!is_null($this->container['pdf417_columns']) && ($this->container['pdf417_columns'] > 30)) {
+            $invalidProperties[] = "invalid value for 'pdf417_columns', must be smaller than or equal to 30.";
+        }
+
+        if (!is_null($this->container['pdf417_columns']) && ($this->container['pdf417_columns'] < 0)) {
+            $invalidProperties[] = "invalid value for 'pdf417_columns', must be bigger than or equal to 0.";
+        }
+
+        if (!is_null($this->container['pdf417_rows']) && ($this->container['pdf417_rows'] > 90)) {
+            $invalidProperties[] = "invalid value for 'pdf417_rows', must be smaller than or equal to 90.";
+        }
+
+        if (!is_null($this->container['pdf417_rows']) && ($this->container['pdf417_rows'] < 0)) {
+            $invalidProperties[] = "invalid value for 'pdf417_rows', must be bigger than or equal to 0.";
+        }
+
+        if (!is_null($this->container['pdf417_aspect_ratio']) && ($this->container['pdf417_aspect_ratio'] > 10)) {
+            $invalidProperties[] = "invalid value for 'pdf417_aspect_ratio', must be smaller than or equal to 10.";
+        }
+
+        if (!is_null($this->container['pdf417_aspect_ratio']) && ($this->container['pdf417_aspect_ratio'] < 2)) {
+            $invalidProperties[] = "invalid value for 'pdf417_aspect_ratio', must be bigger than or equal to 2.";
+        }
+
+        return $invalidProperties;
+    }
+
+    /**
+     * Validate all the properties in the model
+     * return true if all passed
+     *
+     * @return bool True if all properties are valid
+     */
+    public function valid()
+    {
+        if ($this->container['pdf417_columns'] > 30) {
+            return false;
+        }
+        if ($this->container['pdf417_columns'] < 0) {
+            return false;
+        }
+        if ($this->container['pdf417_rows'] > 90) {
+            return false;
+        }
+        if ($this->container['pdf417_rows'] < 0) {
+            return false;
+        }
+        if ($this->container['pdf417_aspect_ratio'] > 10) {
+            return false;
+        }
+        if ($this->container['pdf417_aspect_ratio'] < 2) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Gets pdf417_encode_mode
+     *
+     * @return \Aspose\BarCode\Model\Pdf417EncodeMode
+     */
+    public function getPdf417EncodeMode()
+    {
+        return $this->container['pdf417_encode_mode'];
+    }
+
+    /**
+     * Sets pdf417_encode_mode
+     *
+     * @param \Aspose\BarCode\Model\Pdf417EncodeMode $pdf417_encode_mode pdf417_encode_mode
+     *
+     * @return $this
+     */
+    public function setPdf417EncodeMode($pdf417_encode_mode)
+    {
+        $this->container['pdf417_encode_mode'] = $pdf417_encode_mode;
+
+        return $this;
+    }
+
+    /**
+     * Gets pdf417_error_level
+     *
+     * @return \Aspose\BarCode\Model\Pdf417ErrorLevel
+     */
+    public function getPdf417ErrorLevel()
+    {
+        return $this->container['pdf417_error_level'];
+    }
+
+    /**
+     * Sets pdf417_error_level
+     *
+     * @param \Aspose\BarCode\Model\Pdf417ErrorLevel $pdf417_error_level pdf417_error_level
+     *
+     * @return $this
+     */
+    public function setPdf417ErrorLevel($pdf417_error_level)
+    {
+        $this->container['pdf417_error_level'] = $pdf417_error_level;
+
+        return $this;
+    }
+
+    /**
+     * Gets pdf417_truncate
+     *
+     * @return bool
+     */
+    public function getPdf417Truncate()
+    {
+        return $this->container['pdf417_truncate'];
+    }
+
+    /**
+     * Sets pdf417_truncate
+     *
+     * @param bool $pdf417_truncate Whether to use truncated PDF417 format (removes right-side stop pattern).
+     *
+     * @return $this
+     */
+    public function setPdf417Truncate($pdf417_truncate)
+    {
+        $this->container['pdf417_truncate'] = $pdf417_truncate;
+
+        return $this;
+    }
+
+    /**
+     * Gets pdf417_columns
+     *
+     * @return int
+     */
+    public function getPdf417Columns()
+    {
+        return $this->container['pdf417_columns'];
+    }
+
+    /**
+     * Sets pdf417_columns
+     *
+     * @param int $pdf417_columns Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
+     *
+     * @return $this
+     */
+    public function setPdf417Columns($pdf417_columns)
+    {
+
+        if (!is_null($pdf417_columns) && ($pdf417_columns > 30)) {
+            throw new \InvalidArgumentException('invalid value for $pdf417_columns when calling Pdf417Params., must be smaller than or equal to 30.');
+        }
+        if (!is_null($pdf417_columns) && ($pdf417_columns < 0)) {
+            throw new \InvalidArgumentException('invalid value for $pdf417_columns when calling Pdf417Params., must be bigger than or equal to 0.');
+        }
+
+        $this->container['pdf417_columns'] = $pdf417_columns;
+
+        return $this;
+    }
+
+    /**
+     * Gets pdf417_rows
+     *
+     * @return int
+     */
+    public function getPdf417Rows()
+    {
+        return $this->container['pdf417_rows'];
+    }
+
+    /**
+     * Sets pdf417_rows
+     *
+     * @param int $pdf417_rows Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
+     *
+     * @return $this
+     */
+    public function setPdf417Rows($pdf417_rows)
+    {
+
+        if (!is_null($pdf417_rows) && ($pdf417_rows > 90)) {
+            throw new \InvalidArgumentException('invalid value for $pdf417_rows when calling Pdf417Params., must be smaller than or equal to 90.');
+        }
+        if (!is_null($pdf417_rows) && ($pdf417_rows < 0)) {
+            throw new \InvalidArgumentException('invalid value for $pdf417_rows when calling Pdf417Params., must be bigger than or equal to 0.');
+        }
+
+        $this->container['pdf417_rows'] = $pdf417_rows;
+
+        return $this;
+    }
+
+    /**
+     * Gets pdf417_aspect_ratio
+     *
+     * @return float
+     */
+    public function getPdf417AspectRatio()
+    {
+        return $this->container['pdf417_aspect_ratio'];
+    }
+
+    /**
+     * Sets pdf417_aspect_ratio
+     *
+     * @param float $pdf417_aspect_ratio PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
+     *
+     * @return $this
+     */
+    public function setPdf417AspectRatio($pdf417_aspect_ratio)
+    {
+
+        if (!is_null($pdf417_aspect_ratio) && ($pdf417_aspect_ratio > 10)) {
+            throw new \InvalidArgumentException('invalid value for $pdf417_aspect_ratio when calling Pdf417Params., must be smaller than or equal to 10.');
+        }
+        if (!is_null($pdf417_aspect_ratio) && ($pdf417_aspect_ratio < 2)) {
+            throw new \InvalidArgumentException('invalid value for $pdf417_aspect_ratio when calling Pdf417Params., must be bigger than or equal to 2.');
+        }
+
+        $this->container['pdf417_aspect_ratio'] = $pdf417_aspect_ratio;
+
+        return $this;
+    }
+
+    /**
+     * Gets pdf417_eci_encoding
+     *
+     * @return \Aspose\BarCode\Model\ECIEncodings
+     */
+    public function getPdf417EciEncoding()
+    {
+        return $this->container['pdf417_eci_encoding'];
+    }
+
+    /**
+     * Sets pdf417_eci_encoding
+     *
+     * @param \Aspose\BarCode\Model\ECIEncodings $pdf417_eci_encoding pdf417_eci_encoding
+     *
+     * @return $this
+     */
+    public function setPdf417EciEncoding($pdf417_eci_encoding)
+    {
+        $this->container['pdf417_eci_encoding'] = $pdf417_eci_encoding;
+
+        return $this;
+    }
+
+    /**
+     * Gets pdf417_is_reader_initialization
+     *
+     * @return bool
+     */
+    public function getPdf417IsReaderInitialization()
+    {
+        return $this->container['pdf417_is_reader_initialization'];
+    }
+
+    /**
+     * Sets pdf417_is_reader_initialization
+     *
+     * @param bool $pdf417_is_reader_initialization Whether the barcode is used for reader initialization (programming).
+     *
+     * @return $this
+     */
+    public function setPdf417IsReaderInitialization($pdf417_is_reader_initialization)
+    {
+        $this->container['pdf417_is_reader_initialization'] = $pdf417_is_reader_initialization;
+
+        return $this;
+    }
+
+    /**
+     * Gets pdf417_macro_characters
+     *
+     * @return \Aspose\BarCode\Model\MacroCharacter
+     */
+    public function getPdf417MacroCharacters()
+    {
+        return $this->container['pdf417_macro_characters'];
+    }
+
+    /**
+     * Sets pdf417_macro_characters
+     *
+     * @param \Aspose\BarCode\Model\MacroCharacter $pdf417_macro_characters pdf417_macro_characters
+     *
+     * @return $this
+     */
+    public function setPdf417MacroCharacters($pdf417_macro_characters)
+    {
+        $this->container['pdf417_macro_characters'] = $pdf417_macro_characters;
+
+        return $this;
+    }
+
+    /**
+     * Gets pdf417_is_linked
+     *
+     * @return bool
+     */
+    public function getPdf417IsLinked()
+    {
+        return $this->container['pdf417_is_linked'];
+    }
+
+    /**
+     * Sets pdf417_is_linked
+     *
+     * @param bool $pdf417_is_linked Whether to use linked mode (for MicroPdf417).
+     *
+     * @return $this
+     */
+    public function setPdf417IsLinked($pdf417_is_linked)
+    {
+        $this->container['pdf417_is_linked'] = $pdf417_is_linked;
+
+        return $this;
+    }
+
+    /**
+     * Gets pdf417_is_code128_emulation
+     *
+     * @return bool
+     */
+    public function getPdf417IsCode128Emulation()
+    {
+        return $this->container['pdf417_is_code128_emulation'];
+    }
+
+    /**
+     * Sets pdf417_is_code128_emulation
+     *
+     * @param bool $pdf417_is_code128_emulation Whether to use Code128 emulation for MicroPdf417.
+     *
+     * @return $this
+     */
+    public function setPdf417IsCode128Emulation($pdf417_is_code128_emulation)
+    {
+        $this->container['pdf417_is_code128_emulation'] = $pdf417_is_code128_emulation;
+
+        return $this;
+    }
+
+    /**
+     * Returns true if offset exists. False otherwise.
+     *
+     * @param integer $offset Offset
+     *
+     * @return boolean
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->container[$offset]);
+    }
+
+    /**
+     * Gets offset.
+     *
+     * @param integer $offset Offset
+     *
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        return $this->container[$offset] ?? null;
+    }
+
+    /**
+     * Sets value based on offset.
+     *
+     * @param integer $offset Offset
+     * @param mixed   $value  Value to be set
+     *
+     * @return void
+     */
+    public function offsetSet($offset, $value): void
+    {
+        if (is_null($offset)) {
+            $this->container[] = $value;
+        } else {
+            $this->container[$offset] = $value;
+        }
+    }
+
+    /**
+     * Unsets offset.
+     *
+     * @param integer $offset Offset
+     *
+     * @return void
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->container[$offset]);
+    }
+
+    /**
+     * Gets the string presentation of the object
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
+            return json_encode(
+                ObjectSerializer::sanitizeForSerialization($this),
+                JSON_PRETTY_PRINT
+            );
+        }
+
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
+}

--- a/src/Aspose/BarCode/Model/QREncodeMode.php
+++ b/src/Aspose/BarCode/Model/QREncodeMode.php
@@ -17,16 +17,19 @@ class QREncodeMode
     /// Enum value Auto
     /// </summary>
     public const Auto =  "Auto";
+    public const AUTO = "Auto";
 
     /// <summary>
     /// Enum value Extended
     /// </summary>
     public const Extended =  "Extended";
+    public const EXTENDED = "Extended";
 
     /// <summary>
     /// Enum value Binary
     /// </summary>
     public const Binary =  "Binary";
+    public const BINARY = "Binary";
 
     /// <summary>
     /// Enum value ECI

--- a/src/Aspose/BarCode/Model/QREncodeMode.php
+++ b/src/Aspose/BarCode/Model/QREncodeMode.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * QREncodeMode
+ *
+ * @description QR barcode encode mode. Subset of https://reference.aspose.com/barcode/net/aspose.barcode.generation/qrencodemode/ Obsolete members (Bytes, Utf8BOM, Utf16BEBOM, ECIEncoding, ExtendedCodetext) are omitted.
+ */
+class QREncodeMode
+{
+    /// <summary>
+    /// Enum value Auto
+    /// </summary>
+    public const Auto =  "Auto";
+
+    /// <summary>
+    /// Enum value Extended
+    /// </summary>
+    public const Extended =  "Extended";
+
+    /// <summary>
+    /// Enum value Binary
+    /// </summary>
+    public const Binary =  "Binary";
+
+    /// <summary>
+    /// Enum value ECI
+    /// </summary>
+    public const ECI =  "ECI";
+
+}

--- a/src/Aspose/BarCode/Model/QRErrorLevel.php
+++ b/src/Aspose/BarCode/Model/QRErrorLevel.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * QRErrorLevel
+ *
+ * @description QR barcode error correction level. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/qrerrorlevel/
+ */
+class QRErrorLevel
+{
+    /// <summary>
+    /// Enum value LevelL
+    /// </summary>
+    public const LevelL =  "LevelL";
+
+    /// <summary>
+    /// Enum value LevelM
+    /// </summary>
+    public const LevelM =  "LevelM";
+
+    /// <summary>
+    /// Enum value LevelQ
+    /// </summary>
+    public const LevelQ =  "LevelQ";
+
+    /// <summary>
+    /// Enum value LevelH
+    /// </summary>
+    public const LevelH =  "LevelH";
+
+}

--- a/src/Aspose/BarCode/Model/QRErrorLevel.php
+++ b/src/Aspose/BarCode/Model/QRErrorLevel.php
@@ -17,20 +17,24 @@ class QRErrorLevel
     /// Enum value LevelL
     /// </summary>
     public const LevelL =  "LevelL";
+    public const LEVEL_L = "LevelL";
 
     /// <summary>
     /// Enum value LevelM
     /// </summary>
     public const LevelM =  "LevelM";
+    public const LEVEL_M = "LevelM";
 
     /// <summary>
     /// Enum value LevelQ
     /// </summary>
     public const LevelQ =  "LevelQ";
+    public const LEVEL_Q = "LevelQ";
 
     /// <summary>
     /// Enum value LevelH
     /// </summary>
     public const LevelH =  "LevelH";
+    public const LEVEL_H = "LevelH";
 
 }

--- a/src/Aspose/BarCode/Model/QRVersion.php
+++ b/src/Aspose/BarCode/Model/QRVersion.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * QRVersion
+ *
+ * @description QR barcode version. Subset of https://reference.aspose.com/barcode/net/aspose.barcode.generation/qrversion/ MicroQR versions (VersionM1–VersionM4) are omitted; use Aspose.BarCode.Cloud.DTO.Enums.MicroQRVersion instead.
+ */
+class QRVersion
+{
+    /// <summary>
+    /// Enum value Auto
+    /// </summary>
+    public const Auto =  "Auto";
+
+    /// <summary>
+    /// Enum value Version01
+    /// </summary>
+    public const Version01 =  "Version01";
+
+    /// <summary>
+    /// Enum value Version02
+    /// </summary>
+    public const Version02 =  "Version02";
+
+    /// <summary>
+    /// Enum value Version03
+    /// </summary>
+    public const Version03 =  "Version03";
+
+    /// <summary>
+    /// Enum value Version04
+    /// </summary>
+    public const Version04 =  "Version04";
+
+    /// <summary>
+    /// Enum value Version05
+    /// </summary>
+    public const Version05 =  "Version05";
+
+    /// <summary>
+    /// Enum value Version06
+    /// </summary>
+    public const Version06 =  "Version06";
+
+    /// <summary>
+    /// Enum value Version07
+    /// </summary>
+    public const Version07 =  "Version07";
+
+    /// <summary>
+    /// Enum value Version08
+    /// </summary>
+    public const Version08 =  "Version08";
+
+    /// <summary>
+    /// Enum value Version09
+    /// </summary>
+    public const Version09 =  "Version09";
+
+    /// <summary>
+    /// Enum value Version10
+    /// </summary>
+    public const Version10 =  "Version10";
+
+    /// <summary>
+    /// Enum value Version11
+    /// </summary>
+    public const Version11 =  "Version11";
+
+    /// <summary>
+    /// Enum value Version12
+    /// </summary>
+    public const Version12 =  "Version12";
+
+    /// <summary>
+    /// Enum value Version13
+    /// </summary>
+    public const Version13 =  "Version13";
+
+    /// <summary>
+    /// Enum value Version14
+    /// </summary>
+    public const Version14 =  "Version14";
+
+    /// <summary>
+    /// Enum value Version15
+    /// </summary>
+    public const Version15 =  "Version15";
+
+    /// <summary>
+    /// Enum value Version16
+    /// </summary>
+    public const Version16 =  "Version16";
+
+    /// <summary>
+    /// Enum value Version17
+    /// </summary>
+    public const Version17 =  "Version17";
+
+    /// <summary>
+    /// Enum value Version18
+    /// </summary>
+    public const Version18 =  "Version18";
+
+    /// <summary>
+    /// Enum value Version19
+    /// </summary>
+    public const Version19 =  "Version19";
+
+    /// <summary>
+    /// Enum value Version20
+    /// </summary>
+    public const Version20 =  "Version20";
+
+    /// <summary>
+    /// Enum value Version21
+    /// </summary>
+    public const Version21 =  "Version21";
+
+    /// <summary>
+    /// Enum value Version22
+    /// </summary>
+    public const Version22 =  "Version22";
+
+    /// <summary>
+    /// Enum value Version23
+    /// </summary>
+    public const Version23 =  "Version23";
+
+    /// <summary>
+    /// Enum value Version24
+    /// </summary>
+    public const Version24 =  "Version24";
+
+    /// <summary>
+    /// Enum value Version25
+    /// </summary>
+    public const Version25 =  "Version25";
+
+    /// <summary>
+    /// Enum value Version26
+    /// </summary>
+    public const Version26 =  "Version26";
+
+    /// <summary>
+    /// Enum value Version27
+    /// </summary>
+    public const Version27 =  "Version27";
+
+    /// <summary>
+    /// Enum value Version28
+    /// </summary>
+    public const Version28 =  "Version28";
+
+    /// <summary>
+    /// Enum value Version29
+    /// </summary>
+    public const Version29 =  "Version29";
+
+    /// <summary>
+    /// Enum value Version30
+    /// </summary>
+    public const Version30 =  "Version30";
+
+    /// <summary>
+    /// Enum value Version31
+    /// </summary>
+    public const Version31 =  "Version31";
+
+    /// <summary>
+    /// Enum value Version32
+    /// </summary>
+    public const Version32 =  "Version32";
+
+    /// <summary>
+    /// Enum value Version33
+    /// </summary>
+    public const Version33 =  "Version33";
+
+    /// <summary>
+    /// Enum value Version34
+    /// </summary>
+    public const Version34 =  "Version34";
+
+    /// <summary>
+    /// Enum value Version35
+    /// </summary>
+    public const Version35 =  "Version35";
+
+    /// <summary>
+    /// Enum value Version36
+    /// </summary>
+    public const Version36 =  "Version36";
+
+    /// <summary>
+    /// Enum value Version37
+    /// </summary>
+    public const Version37 =  "Version37";
+
+    /// <summary>
+    /// Enum value Version38
+    /// </summary>
+    public const Version38 =  "Version38";
+
+    /// <summary>
+    /// Enum value Version39
+    /// </summary>
+    public const Version39 =  "Version39";
+
+    /// <summary>
+    /// Enum value Version40
+    /// </summary>
+    public const Version40 =  "Version40";
+
+}

--- a/src/Aspose/BarCode/Model/QRVersion.php
+++ b/src/Aspose/BarCode/Model/QRVersion.php
@@ -17,205 +17,246 @@ class QRVersion
     /// Enum value Auto
     /// </summary>
     public const Auto =  "Auto";
+    public const AUTO = "Auto";
 
     /// <summary>
     /// Enum value Version01
     /// </summary>
     public const Version01 =  "Version01";
+    public const VERSION01 = "Version01";
 
     /// <summary>
     /// Enum value Version02
     /// </summary>
     public const Version02 =  "Version02";
+    public const VERSION02 = "Version02";
 
     /// <summary>
     /// Enum value Version03
     /// </summary>
     public const Version03 =  "Version03";
+    public const VERSION03 = "Version03";
 
     /// <summary>
     /// Enum value Version04
     /// </summary>
     public const Version04 =  "Version04";
+    public const VERSION04 = "Version04";
 
     /// <summary>
     /// Enum value Version05
     /// </summary>
     public const Version05 =  "Version05";
+    public const VERSION05 = "Version05";
 
     /// <summary>
     /// Enum value Version06
     /// </summary>
     public const Version06 =  "Version06";
+    public const VERSION06 = "Version06";
 
     /// <summary>
     /// Enum value Version07
     /// </summary>
     public const Version07 =  "Version07";
+    public const VERSION07 = "Version07";
 
     /// <summary>
     /// Enum value Version08
     /// </summary>
     public const Version08 =  "Version08";
+    public const VERSION08 = "Version08";
 
     /// <summary>
     /// Enum value Version09
     /// </summary>
     public const Version09 =  "Version09";
+    public const VERSION09 = "Version09";
 
     /// <summary>
     /// Enum value Version10
     /// </summary>
     public const Version10 =  "Version10";
+    public const VERSION10 = "Version10";
 
     /// <summary>
     /// Enum value Version11
     /// </summary>
     public const Version11 =  "Version11";
+    public const VERSION11 = "Version11";
 
     /// <summary>
     /// Enum value Version12
     /// </summary>
     public const Version12 =  "Version12";
+    public const VERSION12 = "Version12";
 
     /// <summary>
     /// Enum value Version13
     /// </summary>
     public const Version13 =  "Version13";
+    public const VERSION13 = "Version13";
 
     /// <summary>
     /// Enum value Version14
     /// </summary>
     public const Version14 =  "Version14";
+    public const VERSION14 = "Version14";
 
     /// <summary>
     /// Enum value Version15
     /// </summary>
     public const Version15 =  "Version15";
+    public const VERSION15 = "Version15";
 
     /// <summary>
     /// Enum value Version16
     /// </summary>
     public const Version16 =  "Version16";
+    public const VERSION16 = "Version16";
 
     /// <summary>
     /// Enum value Version17
     /// </summary>
     public const Version17 =  "Version17";
+    public const VERSION17 = "Version17";
 
     /// <summary>
     /// Enum value Version18
     /// </summary>
     public const Version18 =  "Version18";
+    public const VERSION18 = "Version18";
 
     /// <summary>
     /// Enum value Version19
     /// </summary>
     public const Version19 =  "Version19";
+    public const VERSION19 = "Version19";
 
     /// <summary>
     /// Enum value Version20
     /// </summary>
     public const Version20 =  "Version20";
+    public const VERSION20 = "Version20";
 
     /// <summary>
     /// Enum value Version21
     /// </summary>
     public const Version21 =  "Version21";
+    public const VERSION21 = "Version21";
 
     /// <summary>
     /// Enum value Version22
     /// </summary>
     public const Version22 =  "Version22";
+    public const VERSION22 = "Version22";
 
     /// <summary>
     /// Enum value Version23
     /// </summary>
     public const Version23 =  "Version23";
+    public const VERSION23 = "Version23";
 
     /// <summary>
     /// Enum value Version24
     /// </summary>
     public const Version24 =  "Version24";
+    public const VERSION24 = "Version24";
 
     /// <summary>
     /// Enum value Version25
     /// </summary>
     public const Version25 =  "Version25";
+    public const VERSION25 = "Version25";
 
     /// <summary>
     /// Enum value Version26
     /// </summary>
     public const Version26 =  "Version26";
+    public const VERSION26 = "Version26";
 
     /// <summary>
     /// Enum value Version27
     /// </summary>
     public const Version27 =  "Version27";
+    public const VERSION27 = "Version27";
 
     /// <summary>
     /// Enum value Version28
     /// </summary>
     public const Version28 =  "Version28";
+    public const VERSION28 = "Version28";
 
     /// <summary>
     /// Enum value Version29
     /// </summary>
     public const Version29 =  "Version29";
+    public const VERSION29 = "Version29";
 
     /// <summary>
     /// Enum value Version30
     /// </summary>
     public const Version30 =  "Version30";
+    public const VERSION30 = "Version30";
 
     /// <summary>
     /// Enum value Version31
     /// </summary>
     public const Version31 =  "Version31";
+    public const VERSION31 = "Version31";
 
     /// <summary>
     /// Enum value Version32
     /// </summary>
     public const Version32 =  "Version32";
+    public const VERSION32 = "Version32";
 
     /// <summary>
     /// Enum value Version33
     /// </summary>
     public const Version33 =  "Version33";
+    public const VERSION33 = "Version33";
 
     /// <summary>
     /// Enum value Version34
     /// </summary>
     public const Version34 =  "Version34";
+    public const VERSION34 = "Version34";
 
     /// <summary>
     /// Enum value Version35
     /// </summary>
     public const Version35 =  "Version35";
+    public const VERSION35 = "Version35";
 
     /// <summary>
     /// Enum value Version36
     /// </summary>
     public const Version36 =  "Version36";
+    public const VERSION36 = "Version36";
 
     /// <summary>
     /// Enum value Version37
     /// </summary>
     public const Version37 =  "Version37";
+    public const VERSION37 = "Version37";
 
     /// <summary>
     /// Enum value Version38
     /// </summary>
     public const Version38 =  "Version38";
+    public const VERSION38 = "Version38";
 
     /// <summary>
     /// Enum value Version39
     /// </summary>
     public const Version39 =  "Version39";
+    public const VERSION39 = "Version39";
 
     /// <summary>
     /// Enum value Version40
     /// </summary>
     public const Version40 =  "Version40";
+    public const VERSION40 = "Version40";
 
 }

--- a/src/Aspose/BarCode/Model/QrParams.php
+++ b/src/Aspose/BarCode/Model/QrParams.php
@@ -1,0 +1,475 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use ArrayAccess;
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * QrParams
+ *
+ * @description Optional QR barcode generation parameters. Applies to QR, GS1QR, MicroQR, and RectMicroQR barcode types.
+ */
+class QrParams implements ArrayAccess
+{
+    public const DISCRIMINATOR = null;
+
+    /**
+     * The original name of the model.
+     *
+     * @var string
+     */
+    protected static string $swaggerModelName = "QrParams";
+
+    /**
+     * Array of property to type mappings. Used for (de)serialization
+     *
+     * @var string[]
+     */
+    protected static array $swaggerTypes = [
+        'qr_encode_mode' => '\Aspose\BarCode\Model\QREncodeMode',
+        'qr_error_level' => '\Aspose\BarCode\Model\QRErrorLevel',
+        'qr_version' => '\Aspose\BarCode\Model\QRVersion',
+        'qr_eci_encoding' => '\Aspose\BarCode\Model\ECIEncodings',
+        'qr_aspect_ratio' => 'float',
+        'micro_qr_version' => '\Aspose\BarCode\Model\MicroQRVersion',
+        'rect_micro_qr_version' => '\Aspose\BarCode\Model\RectMicroQRVersion'
+    ];
+
+    /**
+     * Array of property to format mappings. Used for (de)serialization
+     *
+     * @var (string|null)[]
+     */
+    protected static array $swaggerFormats = [
+        'qr_encode_mode' => null,
+        'qr_error_level' => null,
+        'qr_version' => null,
+        'qr_eci_encoding' => null,
+        'qr_aspect_ratio' => 'float',
+        'micro_qr_version' => null,
+        'rect_micro_qr_version' => null
+    ];
+
+    /**
+     * Array of property to type mappings. Used for (de)serialization
+     *
+     * @return array
+     */
+    public static function swaggerTypes()
+    {
+        return self::$swaggerTypes;
+    }
+
+    /**
+     * Array of property to format mappings. Used for (de)serialization
+     *
+     * @return array
+     */
+    public static function swaggerFormats()
+    {
+        return self::$swaggerFormats;
+    }
+
+    /**
+     * Array of attributes where the key is the local name,
+     * and the value is the original name
+     *
+     * @var string[]
+     */
+    protected static $attributeMap = [
+        'qr_encode_mode' => 'qrEncodeMode',
+        'qr_error_level' => 'qrErrorLevel',
+        'qr_version' => 'qrVersion',
+        'qr_eci_encoding' => 'qrECIEncoding',
+        'qr_aspect_ratio' => 'qrAspectRatio',
+        'micro_qr_version' => 'microQRVersion',
+        'rect_micro_qr_version' => 'rectMicroQrVersion'
+    ];
+
+    /**
+     * Array of attributes to setter functions (for deserialization of responses)
+     *
+     * @var string[]
+     */
+    protected static $setters = [
+        'qr_encode_mode' => 'setQrEncodeMode',
+        'qr_error_level' => 'setQrErrorLevel',
+        'qr_version' => 'setQrVersion',
+        'qr_eci_encoding' => 'setQrEciEncoding',
+        'qr_aspect_ratio' => 'setQrAspectRatio',
+        'micro_qr_version' => 'setMicroQrVersion',
+        'rect_micro_qr_version' => 'setRectMicroQrVersion'
+    ];
+
+    /**
+     * Array of attributes to getter functions (for serialization of requests)
+     *
+     * @var string[]
+     */
+    protected static $getters = [
+        'qr_encode_mode' => 'getQrEncodeMode',
+        'qr_error_level' => 'getQrErrorLevel',
+        'qr_version' => 'getQrVersion',
+        'qr_eci_encoding' => 'getQrEciEncoding',
+        'qr_aspect_ratio' => 'getQrAspectRatio',
+        'micro_qr_version' => 'getMicroQrVersion',
+        'rect_micro_qr_version' => 'getRectMicroQrVersion'
+    ];
+
+    /**
+     * Array of attributes where the key is the local name,
+     * and the value is the original name
+     *
+     * @return array
+     */
+    public static function attributeMap()
+    {
+        return self::$attributeMap;
+    }
+
+    /**
+     * Array of attributes to setter functions (for deserialization of responses)
+     *
+     * @return array
+     */
+    public static function setters()
+    {
+        return self::$setters;
+    }
+
+    /**
+     * Array of attributes to getter functions (for serialization of requests)
+     *
+     * @return array
+     */
+    public static function getters()
+    {
+        return self::$getters;
+    }
+
+    /**
+     * The original name of the model.
+     *
+     * @return string
+     */
+    public function getModelName()
+    {
+        return self::$swaggerModelName;
+    }
+
+
+
+
+
+    /**
+     * Associative array for storing property values
+     *
+     * @var mixed[]
+     */
+    protected $container = [];
+
+    /**
+     * Constructor
+     *
+     * @param mixed[] $data Associated array of property values
+     *                      initializing the model
+     */
+    public function __construct(?array $data = null)
+    {
+        $this->container['qr_encode_mode'] = isset($data['qr_encode_mode']) ? $data['qr_encode_mode'] : null;
+        $this->container['qr_error_level'] = isset($data['qr_error_level']) ? $data['qr_error_level'] : null;
+        $this->container['qr_version'] = isset($data['qr_version']) ? $data['qr_version'] : null;
+        $this->container['qr_eci_encoding'] = isset($data['qr_eci_encoding']) ? $data['qr_eci_encoding'] : null;
+        $this->container['qr_aspect_ratio'] = isset($data['qr_aspect_ratio']) ? $data['qr_aspect_ratio'] : null;
+        $this->container['micro_qr_version'] = isset($data['micro_qr_version']) ? $data['micro_qr_version'] : null;
+        $this->container['rect_micro_qr_version'] = isset($data['rect_micro_qr_version']) ? $data['rect_micro_qr_version'] : null;
+    }
+
+    /**
+     * Show all the invalid properties with reasons.
+     *
+     * @return array invalid properties with reasons
+     */
+    public function listInvalidProperties()
+    {
+        $invalidProperties = [];
+
+        if (!is_null($this->container['qr_aspect_ratio']) && ($this->container['qr_aspect_ratio'] > 1)) {
+            $invalidProperties[] = "invalid value for 'qr_aspect_ratio', must be smaller than or equal to 1.";
+        }
+
+        if (!is_null($this->container['qr_aspect_ratio']) && ($this->container['qr_aspect_ratio'] < 0.001)) {
+            $invalidProperties[] = "invalid value for 'qr_aspect_ratio', must be bigger than or equal to 0.001.";
+        }
+
+        return $invalidProperties;
+    }
+
+    /**
+     * Validate all the properties in the model
+     * return true if all passed
+     *
+     * @return bool True if all properties are valid
+     */
+    public function valid()
+    {
+        if ($this->container['qr_aspect_ratio'] > 1) {
+            return false;
+        }
+        if ($this->container['qr_aspect_ratio'] < 0.001) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Gets qr_encode_mode
+     *
+     * @return \Aspose\BarCode\Model\QREncodeMode
+     */
+    public function getQrEncodeMode()
+    {
+        return $this->container['qr_encode_mode'];
+    }
+
+    /**
+     * Sets qr_encode_mode
+     *
+     * @param \Aspose\BarCode\Model\QREncodeMode $qr_encode_mode qr_encode_mode
+     *
+     * @return $this
+     */
+    public function setQrEncodeMode($qr_encode_mode)
+    {
+        $this->container['qr_encode_mode'] = $qr_encode_mode;
+
+        return $this;
+    }
+
+    /**
+     * Gets qr_error_level
+     *
+     * @return \Aspose\BarCode\Model\QRErrorLevel
+     */
+    public function getQrErrorLevel()
+    {
+        return $this->container['qr_error_level'];
+    }
+
+    /**
+     * Sets qr_error_level
+     *
+     * @param \Aspose\BarCode\Model\QRErrorLevel $qr_error_level qr_error_level
+     *
+     * @return $this
+     */
+    public function setQrErrorLevel($qr_error_level)
+    {
+        $this->container['qr_error_level'] = $qr_error_level;
+
+        return $this;
+    }
+
+    /**
+     * Gets qr_version
+     *
+     * @return \Aspose\BarCode\Model\QRVersion
+     */
+    public function getQrVersion()
+    {
+        return $this->container['qr_version'];
+    }
+
+    /**
+     * Sets qr_version
+     *
+     * @param \Aspose\BarCode\Model\QRVersion $qr_version qr_version
+     *
+     * @return $this
+     */
+    public function setQrVersion($qr_version)
+    {
+        $this->container['qr_version'] = $qr_version;
+
+        return $this;
+    }
+
+    /**
+     * Gets qr_eci_encoding
+     *
+     * @return \Aspose\BarCode\Model\ECIEncodings
+     */
+    public function getQrEciEncoding()
+    {
+        return $this->container['qr_eci_encoding'];
+    }
+
+    /**
+     * Sets qr_eci_encoding
+     *
+     * @param \Aspose\BarCode\Model\ECIEncodings $qr_eci_encoding qr_eci_encoding
+     *
+     * @return $this
+     */
+    public function setQrEciEncoding($qr_eci_encoding)
+    {
+        $this->container['qr_eci_encoding'] = $qr_eci_encoding;
+
+        return $this;
+    }
+
+    /**
+     * Gets qr_aspect_ratio
+     *
+     * @return float
+     */
+    public function getQrAspectRatio()
+    {
+        return $this->container['qr_aspect_ratio'];
+    }
+
+    /**
+     * Sets qr_aspect_ratio
+     *
+     * @param float $qr_aspect_ratio QR barcode aspect ratio. Values: 0 to 1.
+     *
+     * @return $this
+     */
+    public function setQrAspectRatio($qr_aspect_ratio)
+    {
+
+        if (!is_null($qr_aspect_ratio) && ($qr_aspect_ratio > 1)) {
+            throw new \InvalidArgumentException('invalid value for $qr_aspect_ratio when calling QrParams., must be smaller than or equal to 1.');
+        }
+        if (!is_null($qr_aspect_ratio) && ($qr_aspect_ratio < 0.001)) {
+            throw new \InvalidArgumentException('invalid value for $qr_aspect_ratio when calling QrParams., must be bigger than or equal to 0.001.');
+        }
+
+        $this->container['qr_aspect_ratio'] = $qr_aspect_ratio;
+
+        return $this;
+    }
+
+    /**
+     * Gets micro_qr_version
+     *
+     * @return \Aspose\BarCode\Model\MicroQRVersion
+     */
+    public function getMicroQrVersion()
+    {
+        return $this->container['micro_qr_version'];
+    }
+
+    /**
+     * Sets micro_qr_version
+     *
+     * @param \Aspose\BarCode\Model\MicroQRVersion $micro_qr_version micro_qr_version
+     *
+     * @return $this
+     */
+    public function setMicroQrVersion($micro_qr_version)
+    {
+        $this->container['micro_qr_version'] = $micro_qr_version;
+
+        return $this;
+    }
+
+    /**
+     * Gets rect_micro_qr_version
+     *
+     * @return \Aspose\BarCode\Model\RectMicroQRVersion
+     */
+    public function getRectMicroQrVersion()
+    {
+        return $this->container['rect_micro_qr_version'];
+    }
+
+    /**
+     * Sets rect_micro_qr_version
+     *
+     * @param \Aspose\BarCode\Model\RectMicroQRVersion $rect_micro_qr_version rect_micro_qr_version
+     *
+     * @return $this
+     */
+    public function setRectMicroQrVersion($rect_micro_qr_version)
+    {
+        $this->container['rect_micro_qr_version'] = $rect_micro_qr_version;
+
+        return $this;
+    }
+
+    /**
+     * Returns true if offset exists. False otherwise.
+     *
+     * @param integer $offset Offset
+     *
+     * @return boolean
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->container[$offset]);
+    }
+
+    /**
+     * Gets offset.
+     *
+     * @param integer $offset Offset
+     *
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        return $this->container[$offset] ?? null;
+    }
+
+    /**
+     * Sets value based on offset.
+     *
+     * @param integer $offset Offset
+     * @param mixed   $value  Value to be set
+     *
+     * @return void
+     */
+    public function offsetSet($offset, $value): void
+    {
+        if (is_null($offset)) {
+            $this->container[] = $value;
+        } else {
+            $this->container[$offset] = $value;
+        }
+    }
+
+    /**
+     * Unsets offset.
+     *
+     * @param integer $offset Offset
+     *
+     * @return void
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->container[$offset]);
+    }
+
+    /**
+     * Gets the string presentation of the object
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
+            return json_encode(
+                ObjectSerializer::sanitizeForSerialization($this),
+                JSON_PRETTY_PRINT
+            );
+        }
+
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
+}

--- a/src/Aspose/BarCode/Model/QrParams.php
+++ b/src/Aspose/BarCode/Model/QrParams.php
@@ -239,7 +239,7 @@ class QrParams implements ArrayAccess
     /**
      * Sets qr_encode_mode
      *
-     * @param \Aspose\BarCode\Model\QREncodeMode $qr_encode_mode qr_encode_mode
+     * @param \Aspose\BarCode\Model\QREncodeMode $qr_encode_mode QR barcode encode mode.
      *
      * @return $this
      */
@@ -263,7 +263,7 @@ class QrParams implements ArrayAccess
     /**
      * Sets qr_error_level
      *
-     * @param \Aspose\BarCode\Model\QRErrorLevel $qr_error_level qr_error_level
+     * @param \Aspose\BarCode\Model\QRErrorLevel $qr_error_level QR barcode error correction level.
      *
      * @return $this
      */
@@ -287,7 +287,7 @@ class QrParams implements ArrayAccess
     /**
      * Sets qr_version
      *
-     * @param \Aspose\BarCode\Model\QRVersion $qr_version qr_version
+     * @param \Aspose\BarCode\Model\QRVersion $qr_version QR barcode version. Automatically selects the smallest version that fits the data.
      *
      * @return $this
      */
@@ -311,7 +311,7 @@ class QrParams implements ArrayAccess
     /**
      * Sets qr_eci_encoding
      *
-     * @param \Aspose\BarCode\Model\ECIEncodings $qr_eci_encoding qr_eci_encoding
+     * @param \Aspose\BarCode\Model\ECIEncodings $qr_eci_encoding ECI encoding for QR barcode data.
      *
      * @return $this
      */
@@ -367,7 +367,7 @@ class QrParams implements ArrayAccess
     /**
      * Sets micro_qr_version
      *
-     * @param \Aspose\BarCode\Model\MicroQRVersion $micro_qr_version micro_qr_version
+     * @param \Aspose\BarCode\Model\MicroQRVersion $micro_qr_version MicroQR barcode version. Used when BarcodeType is MicroQR.
      *
      * @return $this
      */
@@ -391,7 +391,7 @@ class QrParams implements ArrayAccess
     /**
      * Sets rect_micro_qr_version
      *
-     * @param \Aspose\BarCode\Model\RectMicroQRVersion $rect_micro_qr_version rect_micro_qr_version
+     * @param \Aspose\BarCode\Model\RectMicroQRVersion $rect_micro_qr_version RectMicroQR barcode version. Used when BarcodeType is RectMicroQR.
      *
      * @return $this
      */
@@ -405,7 +405,7 @@ class QrParams implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -417,7 +417,7 @@ class QrParams implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -430,8 +430,8 @@ class QrParams implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -447,7 +447,7 @@ class QrParams implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/RecognitionImageKind.php
+++ b/src/Aspose/BarCode/Model/RecognitionImageKind.php
@@ -17,15 +17,18 @@ class RecognitionImageKind
     /// Enum value Photo
     /// </summary>
     public const Photo =  "Photo";
+    public const PHOTO = "Photo";
 
     /// <summary>
     /// Enum value ScannedDocument
     /// </summary>
     public const ScannedDocument =  "ScannedDocument";
+    public const SCANNED_DOCUMENT = "ScannedDocument";
 
     /// <summary>
     /// Enum value ClearImage
     /// </summary>
     public const ClearImage =  "ClearImage";
+    public const CLEAR_IMAGE = "ClearImage";
 
 }

--- a/src/Aspose/BarCode/Model/RecognitionMode.php
+++ b/src/Aspose/BarCode/Model/RecognitionMode.php
@@ -17,15 +17,18 @@ class RecognitionMode
     /// Enum value Fast
     /// </summary>
     public const Fast =  "Fast";
+    public const FAST = "Fast";
 
     /// <summary>
     /// Enum value Normal
     /// </summary>
     public const Normal =  "Normal";
+    public const NORMAL = "Normal";
 
     /// <summary>
     /// Enum value Excellent
     /// </summary>
     public const Excellent =  "Excellent";
+    public const EXCELLENT = "Excellent";
 
 }

--- a/src/Aspose/BarCode/Model/RecognizeBase64Request.php
+++ b/src/Aspose/BarCode/Model/RecognizeBase64Request.php
@@ -288,7 +288,7 @@ class RecognizeBase64Request implements ArrayAccess
     /**
      * Sets recognition_mode
      *
-     * @param \Aspose\BarCode\Model\RecognitionMode $recognition_mode recognition_mode
+     * @param \Aspose\BarCode\Model\RecognitionMode $recognition_mode Barcode recognition mode.
      *
      * @return $this
      */
@@ -312,7 +312,7 @@ class RecognizeBase64Request implements ArrayAccess
     /**
      * Sets recognition_image_kind
      *
-     * @param \Aspose\BarCode\Model\RecognitionImageKind $recognition_image_kind recognition_image_kind
+     * @param \Aspose\BarCode\Model\RecognitionImageKind $recognition_image_kind Image kind for recognition.
      *
      * @return $this
      */
@@ -326,7 +326,7 @@ class RecognizeBase64Request implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -338,7 +338,7 @@ class RecognizeBase64Request implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -351,8 +351,8 @@ class RecognizeBase64Request implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -368,7 +368,7 @@ class RecognizeBase64Request implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/RecognizeBase64Request.php
+++ b/src/Aspose/BarCode/Model/RecognizeBase64Request.php
@@ -10,7 +10,7 @@ use Aspose\BarCode\ObjectSerializer;
 /**
  * RecognizeBase64Request
  *
- * @description Barcode recognize request
+ * @description Barcode recognition request.
  */
 class RecognizeBase64Request implements ArrayAccess
 {
@@ -233,7 +233,7 @@ class RecognizeBase64Request implements ArrayAccess
     /**
      * Sets barcode_types
      *
-     * @param \Aspose\BarCode\Model\DecodeBarcodeType[] $barcode_types Array of decode types to find on barcode
+     * @param \Aspose\BarCode\Model\DecodeBarcodeType[] $barcode_types Array of barcode decode types to find.
      *
      * @return $this
      */

--- a/src/Aspose/BarCode/Model/RectMicroQRVersion.php
+++ b/src/Aspose/BarCode/Model/RectMicroQRVersion.php
@@ -17,165 +17,198 @@ class RectMicroQRVersion
     /// Enum value Auto
     /// </summary>
     public const Auto =  "Auto";
+    public const AUTO = "Auto";
 
     /// <summary>
     /// Enum value R7x43
     /// </summary>
     public const R7x43 =  "R7x43";
+    public const R7X43 = "R7x43";
 
     /// <summary>
     /// Enum value R7x59
     /// </summary>
     public const R7x59 =  "R7x59";
+    public const R7X59 = "R7x59";
 
     /// <summary>
     /// Enum value R7x77
     /// </summary>
     public const R7x77 =  "R7x77";
+    public const R7X77 = "R7x77";
 
     /// <summary>
     /// Enum value R7x99
     /// </summary>
     public const R7x99 =  "R7x99";
+    public const R7X99 = "R7x99";
 
     /// <summary>
     /// Enum value R7x139
     /// </summary>
     public const R7x139 =  "R7x139";
+    public const R7X139 = "R7x139";
 
     /// <summary>
     /// Enum value R9x43
     /// </summary>
     public const R9x43 =  "R9x43";
+    public const R9X43 = "R9x43";
 
     /// <summary>
     /// Enum value R9x59
     /// </summary>
     public const R9x59 =  "R9x59";
+    public const R9X59 = "R9x59";
 
     /// <summary>
     /// Enum value R9x77
     /// </summary>
     public const R9x77 =  "R9x77";
+    public const R9X77 = "R9x77";
 
     /// <summary>
     /// Enum value R9x99
     /// </summary>
     public const R9x99 =  "R9x99";
+    public const R9X99 = "R9x99";
 
     /// <summary>
     /// Enum value R9x139
     /// </summary>
     public const R9x139 =  "R9x139";
+    public const R9X139 = "R9x139";
 
     /// <summary>
     /// Enum value R11x27
     /// </summary>
     public const R11x27 =  "R11x27";
+    public const R11X27 = "R11x27";
 
     /// <summary>
     /// Enum value R11x43
     /// </summary>
     public const R11x43 =  "R11x43";
+    public const R11X43 = "R11x43";
 
     /// <summary>
     /// Enum value R11x59
     /// </summary>
     public const R11x59 =  "R11x59";
+    public const R11X59 = "R11x59";
 
     /// <summary>
     /// Enum value R11x77
     /// </summary>
     public const R11x77 =  "R11x77";
+    public const R11X77 = "R11x77";
 
     /// <summary>
     /// Enum value R11x99
     /// </summary>
     public const R11x99 =  "R11x99";
+    public const R11X99 = "R11x99";
 
     /// <summary>
     /// Enum value R11x139
     /// </summary>
     public const R11x139 =  "R11x139";
+    public const R11X139 = "R11x139";
 
     /// <summary>
     /// Enum value R13x27
     /// </summary>
     public const R13x27 =  "R13x27";
+    public const R13X27 = "R13x27";
 
     /// <summary>
     /// Enum value R13x43
     /// </summary>
     public const R13x43 =  "R13x43";
+    public const R13X43 = "R13x43";
 
     /// <summary>
     /// Enum value R13x59
     /// </summary>
     public const R13x59 =  "R13x59";
+    public const R13X59 = "R13x59";
 
     /// <summary>
     /// Enum value R13x77
     /// </summary>
     public const R13x77 =  "R13x77";
+    public const R13X77 = "R13x77";
 
     /// <summary>
     /// Enum value R13x99
     /// </summary>
     public const R13x99 =  "R13x99";
+    public const R13X99 = "R13x99";
 
     /// <summary>
     /// Enum value R13x139
     /// </summary>
     public const R13x139 =  "R13x139";
+    public const R13X139 = "R13x139";
 
     /// <summary>
     /// Enum value R15x43
     /// </summary>
     public const R15x43 =  "R15x43";
+    public const R15X43 = "R15x43";
 
     /// <summary>
     /// Enum value R15x59
     /// </summary>
     public const R15x59 =  "R15x59";
+    public const R15X59 = "R15x59";
 
     /// <summary>
     /// Enum value R15x77
     /// </summary>
     public const R15x77 =  "R15x77";
+    public const R15X77 = "R15x77";
 
     /// <summary>
     /// Enum value R15x99
     /// </summary>
     public const R15x99 =  "R15x99";
+    public const R15X99 = "R15x99";
 
     /// <summary>
     /// Enum value R15x139
     /// </summary>
     public const R15x139 =  "R15x139";
+    public const R15X139 = "R15x139";
 
     /// <summary>
     /// Enum value R17x43
     /// </summary>
     public const R17x43 =  "R17x43";
+    public const R17X43 = "R17x43";
 
     /// <summary>
     /// Enum value R17x59
     /// </summary>
     public const R17x59 =  "R17x59";
+    public const R17X59 = "R17x59";
 
     /// <summary>
     /// Enum value R17x77
     /// </summary>
     public const R17x77 =  "R17x77";
+    public const R17X77 = "R17x77";
 
     /// <summary>
     /// Enum value R17x99
     /// </summary>
     public const R17x99 =  "R17x99";
+    public const R17X99 = "R17x99";
 
     /// <summary>
     /// Enum value R17x139
     /// </summary>
     public const R17x139 =  "R17x139";
+    public const R17X139 = "R17x139";
 
 }

--- a/src/Aspose/BarCode/Model/RectMicroQRVersion.php
+++ b/src/Aspose/BarCode/Model/RectMicroQRVersion.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aspose\BarCode\Model;
+
+use Aspose\BarCode\ObjectSerializer;
+
+/**
+ * RectMicroQRVersion
+ *
+ * @description RectMicroQR barcode version. Mirrors https://reference.aspose.com/barcode/net/aspose.barcode.generation/rectmicroqrversion/
+ */
+class RectMicroQRVersion
+{
+    /// <summary>
+    /// Enum value Auto
+    /// </summary>
+    public const Auto =  "Auto";
+
+    /// <summary>
+    /// Enum value R7x43
+    /// </summary>
+    public const R7x43 =  "R7x43";
+
+    /// <summary>
+    /// Enum value R7x59
+    /// </summary>
+    public const R7x59 =  "R7x59";
+
+    /// <summary>
+    /// Enum value R7x77
+    /// </summary>
+    public const R7x77 =  "R7x77";
+
+    /// <summary>
+    /// Enum value R7x99
+    /// </summary>
+    public const R7x99 =  "R7x99";
+
+    /// <summary>
+    /// Enum value R7x139
+    /// </summary>
+    public const R7x139 =  "R7x139";
+
+    /// <summary>
+    /// Enum value R9x43
+    /// </summary>
+    public const R9x43 =  "R9x43";
+
+    /// <summary>
+    /// Enum value R9x59
+    /// </summary>
+    public const R9x59 =  "R9x59";
+
+    /// <summary>
+    /// Enum value R9x77
+    /// </summary>
+    public const R9x77 =  "R9x77";
+
+    /// <summary>
+    /// Enum value R9x99
+    /// </summary>
+    public const R9x99 =  "R9x99";
+
+    /// <summary>
+    /// Enum value R9x139
+    /// </summary>
+    public const R9x139 =  "R9x139";
+
+    /// <summary>
+    /// Enum value R11x27
+    /// </summary>
+    public const R11x27 =  "R11x27";
+
+    /// <summary>
+    /// Enum value R11x43
+    /// </summary>
+    public const R11x43 =  "R11x43";
+
+    /// <summary>
+    /// Enum value R11x59
+    /// </summary>
+    public const R11x59 =  "R11x59";
+
+    /// <summary>
+    /// Enum value R11x77
+    /// </summary>
+    public const R11x77 =  "R11x77";
+
+    /// <summary>
+    /// Enum value R11x99
+    /// </summary>
+    public const R11x99 =  "R11x99";
+
+    /// <summary>
+    /// Enum value R11x139
+    /// </summary>
+    public const R11x139 =  "R11x139";
+
+    /// <summary>
+    /// Enum value R13x27
+    /// </summary>
+    public const R13x27 =  "R13x27";
+
+    /// <summary>
+    /// Enum value R13x43
+    /// </summary>
+    public const R13x43 =  "R13x43";
+
+    /// <summary>
+    /// Enum value R13x59
+    /// </summary>
+    public const R13x59 =  "R13x59";
+
+    /// <summary>
+    /// Enum value R13x77
+    /// </summary>
+    public const R13x77 =  "R13x77";
+
+    /// <summary>
+    /// Enum value R13x99
+    /// </summary>
+    public const R13x99 =  "R13x99";
+
+    /// <summary>
+    /// Enum value R13x139
+    /// </summary>
+    public const R13x139 =  "R13x139";
+
+    /// <summary>
+    /// Enum value R15x43
+    /// </summary>
+    public const R15x43 =  "R15x43";
+
+    /// <summary>
+    /// Enum value R15x59
+    /// </summary>
+    public const R15x59 =  "R15x59";
+
+    /// <summary>
+    /// Enum value R15x77
+    /// </summary>
+    public const R15x77 =  "R15x77";
+
+    /// <summary>
+    /// Enum value R15x99
+    /// </summary>
+    public const R15x99 =  "R15x99";
+
+    /// <summary>
+    /// Enum value R15x139
+    /// </summary>
+    public const R15x139 =  "R15x139";
+
+    /// <summary>
+    /// Enum value R17x43
+    /// </summary>
+    public const R17x43 =  "R17x43";
+
+    /// <summary>
+    /// Enum value R17x59
+    /// </summary>
+    public const R17x59 =  "R17x59";
+
+    /// <summary>
+    /// Enum value R17x77
+    /// </summary>
+    public const R17x77 =  "R17x77";
+
+    /// <summary>
+    /// Enum value R17x99
+    /// </summary>
+    public const R17x99 =  "R17x99";
+
+    /// <summary>
+    /// Enum value R17x139
+    /// </summary>
+    public const R17x139 =  "R17x139";
+
+}

--- a/src/Aspose/BarCode/Model/RegionPoint.php
+++ b/src/Aspose/BarCode/Model/RegionPoint.php
@@ -233,7 +233,7 @@ class RegionPoint implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -245,7 +245,7 @@ class RegionPoint implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -258,8 +258,8 @@ class RegionPoint implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -275,7 +275,7 @@ class RegionPoint implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/Model/ScanBase64Request.php
+++ b/src/Aspose/BarCode/Model/ScanBase64Request.php
@@ -221,7 +221,7 @@ class ScanBase64Request implements ArrayAccess
     /**
      * Returns true if offset exists. False otherwise.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return boolean
      */
@@ -233,7 +233,7 @@ class ScanBase64Request implements ArrayAccess
     /**
      * Gets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return mixed
      */
@@ -246,8 +246,8 @@ class ScanBase64Request implements ArrayAccess
     /**
      * Sets value based on offset.
      *
-     * @param integer $offset Offset
-     * @param mixed   $value  Value to be set
+     * @param string $offset Offset
+     * @param mixed  $value  Value to be set
      *
      * @return void
      */
@@ -263,7 +263,7 @@ class ScanBase64Request implements ArrayAccess
     /**
      * Unsets offset.
      *
-     * @param integer $offset Offset
+     * @param string $offset Offset
      *
      * @return void
      */

--- a/src/Aspose/BarCode/RecognizeApi.php
+++ b/src/Aspose/BarCode/RecognizeApi.php
@@ -90,7 +90,7 @@ class RecognizeApi
     /**
      * Operation recognize
      *
-     * Recognize barcode from file on server in the Internet using GET requests with parameter in query string. For recognizing files from your hard drive use `recognize-body` or `recognize-multipart` endpoints instead.
+     * Recognize a barcode from a file on an Internet server using a GET request with a query string parameter. For recognizing files from your hard drive, use `recognize-body` or `recognize-multipart` endpoints instead.
      *
      * @param Requests\RecognizeRequestWrapper $request is a request object for operation
      *
@@ -112,7 +112,7 @@ class RecognizeApi
     /**
      * Operation recognizeWithHttpInfo
      *
-     * Recognize barcode from file on server in the Internet using GET requests with parameter in query string. For recognizing files from your hard drive use `recognize-body` or `recognize-multipart` endpoints instead.
+     * Recognize a barcode from a file on an Internet server using a GET request with a query string parameter. For recognizing files from your hard drive, use `recognize-body` or `recognize-multipart` endpoints instead.
      *
      * @param Requests\RecognizeRequestWrapper $request is a request object for operation
      *
@@ -176,7 +176,7 @@ class RecognizeApi
     /**
      * Operation recognizeAsync
      *
-     * Recognize barcode from file on server in the Internet using GET requests with parameter in query string. For recognizing files from your hard drive use `recognize-body` or `recognize-multipart` endpoints instead.
+     * Recognize a barcode from a file on an Internet server using a GET request with a query string parameter. For recognizing files from your hard drive, use `recognize-body` or `recognize-multipart` endpoints instead.
      *
      * @param Requests\RecognizeRequestWrapper $request is a request object for operation
      *
@@ -196,7 +196,7 @@ class RecognizeApi
     /**
      * Operation recognizeAsyncWithHttpInfo
      *
-     * Recognize barcode from file on server in the Internet using GET requests with parameter in query string. For recognizing files from your hard drive use `recognize-body` or `recognize-multipart` endpoints instead.
+     * Recognize a barcode from a file on an Internet server using a GET request with a query string parameter. For recognizing files from your hard drive, use `recognize-body` or `recognize-multipart` endpoints instead.
      *
      * @param Requests\RecognizeRequestWrapper $request is a request object for operation
      *
@@ -365,7 +365,7 @@ class RecognizeApi
     /**
      * Operation recognizeBase64
      *
-     * Recognize barcode from file in request body using POST requests with parameters in body in json or xml format.
+     * Recognize a barcode from a file in the request body using a POST request with JSON or XML body parameters.
      *
      * @param Requests\RecognizeBase64RequestWrapper $request is a request object for operation
      *
@@ -387,7 +387,7 @@ class RecognizeApi
     /**
      * Operation recognizeBase64WithHttpInfo
      *
-     * Recognize barcode from file in request body using POST requests with parameters in body in json or xml format.
+     * Recognize a barcode from a file in the request body using a POST request with JSON or XML body parameters.
      *
      * @param Requests\RecognizeBase64RequestWrapper $request is a request object for operation
      *
@@ -451,7 +451,7 @@ class RecognizeApi
     /**
      * Operation recognizeBase64Async
      *
-     * Recognize barcode from file in request body using POST requests with parameters in body in json or xml format.
+     * Recognize a barcode from a file in the request body using a POST request with JSON or XML body parameters.
      *
      * @param Requests\RecognizeBase64RequestWrapper $request is a request object for operation
      *
@@ -471,7 +471,7 @@ class RecognizeApi
     /**
      * Operation recognizeBase64AsyncWithHttpInfo
      *
-     * Recognize barcode from file in request body using POST requests with parameters in body in json or xml format.
+     * Recognize a barcode from a file in the request body using a POST request with JSON or XML body parameters.
      *
      * @param Requests\RecognizeBase64RequestWrapper $request is a request object for operation
      *
@@ -613,7 +613,7 @@ class RecognizeApi
     /**
      * Operation recognizeMultipart
      *
-     * Recognize barcode from file in request body using POST requests with parameters in multipart form.
+     * Recognize a barcode from a file in the request body using a POST request with multipart form parameters.
      *
      * @param Requests\RecognizeMultipartRequestWrapper $request is a request object for operation
      *
@@ -635,7 +635,7 @@ class RecognizeApi
     /**
      * Operation recognizeMultipartWithHttpInfo
      *
-     * Recognize barcode from file in request body using POST requests with parameters in multipart form.
+     * Recognize a barcode from a file in the request body using a POST request with multipart form parameters.
      *
      * @param Requests\RecognizeMultipartRequestWrapper $request is a request object for operation
      *
@@ -699,7 +699,7 @@ class RecognizeApi
     /**
      * Operation recognizeMultipartAsync
      *
-     * Recognize barcode from file in request body using POST requests with parameters in multipart form.
+     * Recognize a barcode from a file in the request body using a POST request with multipart form parameters.
      *
      * @param Requests\RecognizeMultipartRequestWrapper $request is a request object for operation
      *
@@ -719,7 +719,7 @@ class RecognizeApi
     /**
      * Operation recognizeMultipartAsyncWithHttpInfo
      *
-     * Recognize barcode from file in request body using POST requests with parameters in multipart form.
+     * Recognize a barcode from a file in the request body using a POST request with multipart form parameters.
      *
      * @param Requests\RecognizeMultipartRequestWrapper $request is a request object for operation
      *

--- a/src/Aspose/BarCode/Requests/GenerateBodyRequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/GenerateBodyRequestWrapper.php
@@ -20,7 +20,7 @@ class GenerateBodyRequestWrapper
     /**
      * Initializes a new instance of the GenerateBodyRequestWrapper class.
      *
-     * @param \Aspose\BarCode\Model\GenerateParams $generate_params Parameters of generation
+     * @param \Aspose\BarCode\Model\GenerateParams $generate_params Generation parameters.
      */
     public function __construct($generate_params)
     {
@@ -28,7 +28,7 @@ class GenerateBodyRequestWrapper
     }
 
     /**
-     * Parameters of generation
+     * Generation parameters.
      */
     public $generate_params;
 }

--- a/src/Aspose/BarCode/Requests/GenerateMultipartRequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/GenerateMultipartRequestWrapper.php
@@ -21,19 +21,38 @@ class GenerateMultipartRequestWrapper
      * Initializes a new instance of the GenerateMultipartRequestWrapper class.
      *
      * @param \Aspose\BarCode\Model\EncodeBarcodeType $barcode_type
-     * @param string $data String represents data to encode
+     * @param string $data String that represents the data to encode.
      * @param \Aspose\BarCode\Model\EncodeDataType $data_type
      * @param \Aspose\BarCode\Model\BarcodeImageFormat $image_format
      * @param \Aspose\BarCode\Model\CodeLocation $text_location
-     * @param string $foreground_color Specify the displaying bars and content Color. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: Black.
-     * @param string $background_color Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: White.
+     * @param string $foreground_color Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
+     * @param string $background_color Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
      * @param \Aspose\BarCode\Model\GraphicsUnit $units
-     * @param float $resolution Resolution of the BarCode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is dot.
-     * @param float $image_height Height of the barcode image in given units. Default units: pixel. Decimal separator is dot.
-     * @param float $image_width Width of the barcode image in given units. Default units: pixel. Decimal separator is dot.
-     * @param int $rotation_angle BarCode image rotation angle, measured in degree, e.g. RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle NOT equal to 90, 180, 270 or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
+     * @param float $resolution Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
+     * @param float $image_height Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
+     * @param float $image_width Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
+     * @param int $rotation_angle Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
+     * @param \Aspose\BarCode\Model\QREncodeMode $qr_encode_mode
+     * @param \Aspose\BarCode\Model\QRErrorLevel $qr_error_level
+     * @param \Aspose\BarCode\Model\QRVersion $qr_version
+     * @param \Aspose\BarCode\Model\ECIEncodings $qr_eci_encoding
+     * @param float $qr_aspect_ratio QR barcode aspect ratio. Values: 0 to 1.
+     * @param \Aspose\BarCode\Model\MicroQRVersion $micro_qr_version
+     * @param \Aspose\BarCode\Model\RectMicroQRVersion $rect_micro_qr_version
+     * @param \Aspose\BarCode\Model\Code128EncodeMode $code128_encode_mode
+     * @param \Aspose\BarCode\Model\Pdf417EncodeMode $pdf417_encode_mode
+     * @param \Aspose\BarCode\Model\Pdf417ErrorLevel $pdf417_error_level
+     * @param bool $pdf417_truncate Whether to use truncated PDF417 format (removes right-side stop pattern).
+     * @param int $pdf417_columns Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
+     * @param int $pdf417_rows Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
+     * @param float $pdf417_aspect_ratio PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
+     * @param \Aspose\BarCode\Model\ECIEncodings $pdf417_eci_encoding
+     * @param bool $pdf417_is_reader_initialization Whether the barcode is used for reader initialization (programming).
+     * @param \Aspose\BarCode\Model\MacroCharacter $pdf417_macro_characters
+     * @param bool $pdf417_is_linked Whether to use linked mode (for MicroPdf417).
+     * @param bool $pdf417_is_code128_emulation Whether to use Code128 emulation for MicroPdf417.
      */
-    public function __construct($barcode_type, $data, $data_type = null, $image_format = null, $text_location = null, $foreground_color = null, $background_color = null, $units = null, $resolution = null, $image_height = null, $image_width = null, $rotation_angle = null)
+    public function __construct($barcode_type, $data, $data_type = null, $image_format = null, $text_location = null, $foreground_color = null, $background_color = null, $units = null, $resolution = null, $image_height = null, $image_width = null, $rotation_angle = null, $qr_encode_mode = null, $qr_error_level = null, $qr_version = null, $qr_eci_encoding = null, $qr_aspect_ratio = null, $micro_qr_version = null, $rect_micro_qr_version = null, $code128_encode_mode = null, $pdf417_encode_mode = null, $pdf417_error_level = null, $pdf417_truncate = null, $pdf417_columns = null, $pdf417_rows = null, $pdf417_aspect_ratio = null, $pdf417_eci_encoding = null, $pdf417_is_reader_initialization = null, $pdf417_macro_characters = null, $pdf417_is_linked = null, $pdf417_is_code128_emulation = null)
     {
         $this->barcode_type = $barcode_type;
         $this->data = $data;
@@ -47,6 +66,25 @@ class GenerateMultipartRequestWrapper
         $this->image_height = $image_height;
         $this->image_width = $image_width;
         $this->rotation_angle = $rotation_angle;
+        $this->qr_encode_mode = $qr_encode_mode;
+        $this->qr_error_level = $qr_error_level;
+        $this->qr_version = $qr_version;
+        $this->qr_eci_encoding = $qr_eci_encoding;
+        $this->qr_aspect_ratio = $qr_aspect_ratio;
+        $this->micro_qr_version = $micro_qr_version;
+        $this->rect_micro_qr_version = $rect_micro_qr_version;
+        $this->code128_encode_mode = $code128_encode_mode;
+        $this->pdf417_encode_mode = $pdf417_encode_mode;
+        $this->pdf417_error_level = $pdf417_error_level;
+        $this->pdf417_truncate = $pdf417_truncate;
+        $this->pdf417_columns = $pdf417_columns;
+        $this->pdf417_rows = $pdf417_rows;
+        $this->pdf417_aspect_ratio = $pdf417_aspect_ratio;
+        $this->pdf417_eci_encoding = $pdf417_eci_encoding;
+        $this->pdf417_is_reader_initialization = $pdf417_is_reader_initialization;
+        $this->pdf417_macro_characters = $pdf417_macro_characters;
+        $this->pdf417_is_linked = $pdf417_is_linked;
+        $this->pdf417_is_code128_emulation = $pdf417_is_code128_emulation;
     }
 
     /**
@@ -55,7 +93,7 @@ class GenerateMultipartRequestWrapper
     public $barcode_type;
 
     /**
-     * String represents data to encode
+     * String that represents the data to encode.
      */
     public $data;
 
@@ -75,12 +113,12 @@ class GenerateMultipartRequestWrapper
     public $text_location;
 
     /**
-     * Specify the displaying bars and content Color. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: Black.
+     * Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
      */
     public $foreground_color;
 
     /**
-     * Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: White.
+     * Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
      */
     public $background_color;
 
@@ -90,22 +128,117 @@ class GenerateMultipartRequestWrapper
     public $units;
 
     /**
-     * Resolution of the BarCode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is dot.
+     * Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
      */
     public $resolution;
 
     /**
-     * Height of the barcode image in given units. Default units: pixel. Decimal separator is dot.
+     * Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
      */
     public $image_height;
 
     /**
-     * Width of the barcode image in given units. Default units: pixel. Decimal separator is dot.
+     * Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
      */
     public $image_width;
 
     /**
-     * BarCode image rotation angle, measured in degree, e.g. RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle NOT equal to 90, 180, 270 or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
+     * Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
      */
     public $rotation_angle;
+
+    /**
+     * Gets or sets qr_encode_mode
+     */
+    public $qr_encode_mode;
+
+    /**
+     * Gets or sets qr_error_level
+     */
+    public $qr_error_level;
+
+    /**
+     * Gets or sets qr_version
+     */
+    public $qr_version;
+
+    /**
+     * Gets or sets qr_eci_encoding
+     */
+    public $qr_eci_encoding;
+
+    /**
+     * QR barcode aspect ratio. Values: 0 to 1.
+     */
+    public $qr_aspect_ratio;
+
+    /**
+     * Gets or sets micro_qr_version
+     */
+    public $micro_qr_version;
+
+    /**
+     * Gets or sets rect_micro_qr_version
+     */
+    public $rect_micro_qr_version;
+
+    /**
+     * Gets or sets code128_encode_mode
+     */
+    public $code128_encode_mode;
+
+    /**
+     * Gets or sets pdf417_encode_mode
+     */
+    public $pdf417_encode_mode;
+
+    /**
+     * Gets or sets pdf417_error_level
+     */
+    public $pdf417_error_level;
+
+    /**
+     * Whether to use truncated PDF417 format (removes right-side stop pattern).
+     */
+    public $pdf417_truncate;
+
+    /**
+     * Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
+     */
+    public $pdf417_columns;
+
+    /**
+     * Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
+     */
+    public $pdf417_rows;
+
+    /**
+     * PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
+     */
+    public $pdf417_aspect_ratio;
+
+    /**
+     * Gets or sets pdf417_eci_encoding
+     */
+    public $pdf417_eci_encoding;
+
+    /**
+     * Whether the barcode is used for reader initialization (programming).
+     */
+    public $pdf417_is_reader_initialization;
+
+    /**
+     * Gets or sets pdf417_macro_characters
+     */
+    public $pdf417_macro_characters;
+
+    /**
+     * Whether to use linked mode (for MicroPdf417).
+     */
+    public $pdf417_is_linked;
+
+    /**
+     * Whether to use Code128 emulation for MicroPdf417.
+     */
+    public $pdf417_is_code128_emulation;
 }

--- a/src/Aspose/BarCode/Requests/GenerateMultipartRequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/GenerateMultipartRequestWrapper.php
@@ -20,75 +20,27 @@ class GenerateMultipartRequestWrapper
     /**
      * Initializes a new instance of the GenerateMultipartRequestWrapper class.
      *
-     * @param \Aspose\BarCode\Model\EncodeBarcodeType $barcode_type
+     * @param \Aspose\BarCode\Model\EncodeBarcodeType $barcode_type See https://reference.aspose.com/barcode/net/aspose.barcode.generation/encodetypes/
      * @param string $data String that represents the data to encode.
-     * @param \Aspose\BarCode\Model\EncodeDataType $data_type
-     * @param \Aspose\BarCode\Model\BarcodeImageFormat $image_format
-     * @param \Aspose\BarCode\Model\CodeLocation $text_location
-     * @param string $foreground_color Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
-     * @param string $background_color Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
-     * @param \Aspose\BarCode\Model\GraphicsUnit $units
-     * @param float $resolution Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
-     * @param float $image_height Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
-     * @param float $image_width Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
-     * @param int $rotation_angle Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
-     * @param \Aspose\BarCode\Model\QREncodeMode $qr_encode_mode
-     * @param \Aspose\BarCode\Model\QRErrorLevel $qr_error_level
-     * @param \Aspose\BarCode\Model\QRVersion $qr_version
-     * @param \Aspose\BarCode\Model\ECIEncodings $qr_eci_encoding
-     * @param float $qr_aspect_ratio QR barcode aspect ratio. Values: 0 to 1.
-     * @param \Aspose\BarCode\Model\MicroQRVersion $micro_qr_version
-     * @param \Aspose\BarCode\Model\RectMicroQRVersion $rect_micro_qr_version
-     * @param \Aspose\BarCode\Model\Code128EncodeMode $code128_encode_mode
-     * @param \Aspose\BarCode\Model\Pdf417EncodeMode $pdf417_encode_mode
-     * @param \Aspose\BarCode\Model\Pdf417ErrorLevel $pdf417_error_level
-     * @param bool $pdf417_truncate Whether to use truncated PDF417 format (removes right-side stop pattern).
-     * @param int $pdf417_columns Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
-     * @param int $pdf417_rows Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
-     * @param float $pdf417_aspect_ratio PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
-     * @param \Aspose\BarCode\Model\ECIEncodings $pdf417_eci_encoding
-     * @param bool $pdf417_is_reader_initialization Whether the barcode is used for reader initialization (programming).
-     * @param \Aspose\BarCode\Model\MacroCharacter $pdf417_macro_characters
-     * @param bool $pdf417_is_linked Whether to use linked mode (for MicroPdf417).
-     * @param bool $pdf417_is_code128_emulation Whether to use Code128 emulation for MicroPdf417.
+     * @param \Aspose\BarCode\Model\EncodeDataType $data_type Type of data to encode. Default value: StringData.
+     * @param \Aspose\BarCode\Model\BarcodeImageParams $barcode_image_params Grouped parameters for BarcodeImageParams.
+     * @param \Aspose\BarCode\Model\QrParams $qr_params Grouped parameters for QrParams.
+     * @param \Aspose\BarCode\Model\Code128Params $code128_params Grouped parameters for Code128Params.
+     * @param \Aspose\BarCode\Model\Pdf417Params $pdf417_params Grouped parameters for Pdf417Params.
      */
-    public function __construct($barcode_type, $data, $data_type = null, $image_format = null, $text_location = null, $foreground_color = null, $background_color = null, $units = null, $resolution = null, $image_height = null, $image_width = null, $rotation_angle = null, $qr_encode_mode = null, $qr_error_level = null, $qr_version = null, $qr_eci_encoding = null, $qr_aspect_ratio = null, $micro_qr_version = null, $rect_micro_qr_version = null, $code128_encode_mode = null, $pdf417_encode_mode = null, $pdf417_error_level = null, $pdf417_truncate = null, $pdf417_columns = null, $pdf417_rows = null, $pdf417_aspect_ratio = null, $pdf417_eci_encoding = null, $pdf417_is_reader_initialization = null, $pdf417_macro_characters = null, $pdf417_is_linked = null, $pdf417_is_code128_emulation = null)
+    public function __construct($barcode_type, $data, $data_type = null, $barcode_image_params = null, $qr_params = null, $code128_params = null, $pdf417_params = null)
     {
         $this->barcode_type = $barcode_type;
         $this->data = $data;
         $this->data_type = $data_type;
-        $this->image_format = $image_format;
-        $this->text_location = $text_location;
-        $this->foreground_color = $foreground_color;
-        $this->background_color = $background_color;
-        $this->units = $units;
-        $this->resolution = $resolution;
-        $this->image_height = $image_height;
-        $this->image_width = $image_width;
-        $this->rotation_angle = $rotation_angle;
-        $this->qr_encode_mode = $qr_encode_mode;
-        $this->qr_error_level = $qr_error_level;
-        $this->qr_version = $qr_version;
-        $this->qr_eci_encoding = $qr_eci_encoding;
-        $this->qr_aspect_ratio = $qr_aspect_ratio;
-        $this->micro_qr_version = $micro_qr_version;
-        $this->rect_micro_qr_version = $rect_micro_qr_version;
-        $this->code128_encode_mode = $code128_encode_mode;
-        $this->pdf417_encode_mode = $pdf417_encode_mode;
-        $this->pdf417_error_level = $pdf417_error_level;
-        $this->pdf417_truncate = $pdf417_truncate;
-        $this->pdf417_columns = $pdf417_columns;
-        $this->pdf417_rows = $pdf417_rows;
-        $this->pdf417_aspect_ratio = $pdf417_aspect_ratio;
-        $this->pdf417_eci_encoding = $pdf417_eci_encoding;
-        $this->pdf417_is_reader_initialization = $pdf417_is_reader_initialization;
-        $this->pdf417_macro_characters = $pdf417_macro_characters;
-        $this->pdf417_is_linked = $pdf417_is_linked;
-        $this->pdf417_is_code128_emulation = $pdf417_is_code128_emulation;
+        $this->barcode_image_params = $barcode_image_params;
+        $this->qr_params = $qr_params;
+        $this->code128_params = $code128_params;
+        $this->pdf417_params = $pdf417_params;
     }
 
     /**
-     * Gets or sets barcode_type
+     * See https://reference.aspose.com/barcode/net/aspose.barcode.generation/encodetypes/
      */
     public $barcode_type;
 
@@ -98,147 +50,35 @@ class GenerateMultipartRequestWrapper
     public $data;
 
     /**
-     * Gets or sets data_type
+     * Type of data to encode. Default value: StringData.
      */
     public $data_type;
 
     /**
-     * Gets or sets image_format
+     * Grouped parameters for BarcodeImageParams.
+     *
+     * @var \Aspose\BarCode\Model\BarcodeImageParams|null
      */
-    public $image_format;
+    public $barcode_image_params;
 
     /**
-     * Gets or sets text_location
+     * Grouped parameters for QrParams.
+     *
+     * @var \Aspose\BarCode\Model\QrParams|null
      */
-    public $text_location;
+    public $qr_params;
 
     /**
-     * Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
+     * Grouped parameters for Code128Params.
+     *
+     * @var \Aspose\BarCode\Model\Code128Params|null
      */
-    public $foreground_color;
+    public $code128_params;
 
     /**
-     * Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
+     * Grouped parameters for Pdf417Params.
+     *
+     * @var \Aspose\BarCode\Model\Pdf417Params|null
      */
-    public $background_color;
-
-    /**
-     * Gets or sets units
-     */
-    public $units;
-
-    /**
-     * Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
-     */
-    public $resolution;
-
-    /**
-     * Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
-     */
-    public $image_height;
-
-    /**
-     * Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
-     */
-    public $image_width;
-
-    /**
-     * Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
-     */
-    public $rotation_angle;
-
-    /**
-     * Gets or sets qr_encode_mode
-     */
-    public $qr_encode_mode;
-
-    /**
-     * Gets or sets qr_error_level
-     */
-    public $qr_error_level;
-
-    /**
-     * Gets or sets qr_version
-     */
-    public $qr_version;
-
-    /**
-     * Gets or sets qr_eci_encoding
-     */
-    public $qr_eci_encoding;
-
-    /**
-     * QR barcode aspect ratio. Values: 0 to 1.
-     */
-    public $qr_aspect_ratio;
-
-    /**
-     * Gets or sets micro_qr_version
-     */
-    public $micro_qr_version;
-
-    /**
-     * Gets or sets rect_micro_qr_version
-     */
-    public $rect_micro_qr_version;
-
-    /**
-     * Gets or sets code128_encode_mode
-     */
-    public $code128_encode_mode;
-
-    /**
-     * Gets or sets pdf417_encode_mode
-     */
-    public $pdf417_encode_mode;
-
-    /**
-     * Gets or sets pdf417_error_level
-     */
-    public $pdf417_error_level;
-
-    /**
-     * Whether to use truncated PDF417 format (removes right-side stop pattern).
-     */
-    public $pdf417_truncate;
-
-    /**
-     * Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
-     */
-    public $pdf417_columns;
-
-    /**
-     * Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
-     */
-    public $pdf417_rows;
-
-    /**
-     * PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
-     */
-    public $pdf417_aspect_ratio;
-
-    /**
-     * Gets or sets pdf417_eci_encoding
-     */
-    public $pdf417_eci_encoding;
-
-    /**
-     * Whether the barcode is used for reader initialization (programming).
-     */
-    public $pdf417_is_reader_initialization;
-
-    /**
-     * Gets or sets pdf417_macro_characters
-     */
-    public $pdf417_macro_characters;
-
-    /**
-     * Whether to use linked mode (for MicroPdf417).
-     */
-    public $pdf417_is_linked;
-
-    /**
-     * Whether to use Code128 emulation for MicroPdf417.
-     */
-    public $pdf417_is_code128_emulation;
+    public $pdf417_params;
 }

--- a/src/Aspose/BarCode/Requests/GenerateRequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/GenerateRequestWrapper.php
@@ -21,19 +21,38 @@ class GenerateRequestWrapper
      * Initializes a new instance of the GenerateRequestWrapper class.
      *
      * @param \Aspose\BarCode\Model\EncodeBarcodeType $barcode_type Type of barcode to generate.
-     * @param string $data String represents data to encode
+     * @param string $data String that represents the data to encode.
      * @param \Aspose\BarCode\Model\EncodeDataType $data_type Type of data to encode. Default value: StringData.
-     * @param \Aspose\BarCode\Model\BarcodeImageFormat $image_format Barcode output image format. Default value: png
-     * @param \Aspose\BarCode\Model\CodeLocation $text_location Specify the displaying Text Location, set to CodeLocation.None to hide CodeText. Default value: Depends on BarcodeType. CodeLocation.Below for 1D Barcodes. CodeLocation.None for 2D Barcodes.
-     * @param string $foreground_color Specify the displaying bars and content Color. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: Black.
-     * @param string $background_color Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: White.
-     * @param \Aspose\BarCode\Model\GraphicsUnit $units Common Units for all measuring in query. Default units: pixel.
-     * @param float $resolution Resolution of the BarCode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is dot.
-     * @param float $image_height Height of the barcode image in given units. Default units: pixel. Decimal separator is dot.
-     * @param float $image_width Width of the barcode image in given units. Default units: pixel. Decimal separator is dot.
-     * @param int $rotation_angle BarCode image rotation angle, measured in degree, e.g. RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle NOT equal to 90, 180, 270 or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
+     * @param \Aspose\BarCode\Model\BarcodeImageFormat $image_format Barcode output image format. Default value: png.
+     * @param \Aspose\BarCode\Model\CodeLocation $text_location Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes.
+     * @param string $foreground_color Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
+     * @param string $background_color Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
+     * @param \Aspose\BarCode\Model\GraphicsUnit $units Common units for all measurements. Default units: pixels.
+     * @param float $resolution Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
+     * @param float $image_height Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
+     * @param float $image_width Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
+     * @param int $rotation_angle Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
+     * @param \Aspose\BarCode\Model\QREncodeMode $qr_encode_mode QR barcode encode mode.
+     * @param \Aspose\BarCode\Model\QRErrorLevel $qr_error_level QR barcode error correction level.
+     * @param \Aspose\BarCode\Model\QRVersion $qr_version QR barcode version. Automatically selects the smallest version that fits the data.
+     * @param \Aspose\BarCode\Model\ECIEncodings $qr_eci_encoding ECI encoding for QR barcode data.
+     * @param float $qr_aspect_ratio QR barcode aspect ratio. Values: 0 to 1.
+     * @param \Aspose\BarCode\Model\MicroQRVersion $micro_qr_version MicroQR barcode version. Used when BarcodeType is MicroQR.
+     * @param \Aspose\BarCode\Model\RectMicroQRVersion $rect_micro_qr_version RectMicroQR barcode version. Used when BarcodeType is RectMicroQR.
+     * @param \Aspose\BarCode\Model\Code128EncodeMode $code128_encode_mode Code128 barcode encode mode. Controls which Code 128 subset (A, B, C, or mix) is used.
+     * @param \Aspose\BarCode\Model\Pdf417EncodeMode $pdf417_encode_mode PDF417 barcode encode mode.
+     * @param \Aspose\BarCode\Model\Pdf417ErrorLevel $pdf417_error_level PDF417 barcode error correction level.
+     * @param bool $pdf417_truncate Whether to use truncated PDF417 format (removes right-side stop pattern).
+     * @param int $pdf417_columns Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
+     * @param int $pdf417_rows Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
+     * @param float $pdf417_aspect_ratio PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
+     * @param \Aspose\BarCode\Model\ECIEncodings $pdf417_eci_encoding ECI encoding for PDF417 barcode data.
+     * @param bool $pdf417_is_reader_initialization Whether the barcode is used for reader initialization (programming).
+     * @param \Aspose\BarCode\Model\MacroCharacter $pdf417_macro_characters Macro character to prepend (structured append).
+     * @param bool $pdf417_is_linked Whether to use linked mode (for MicroPdf417).
+     * @param bool $pdf417_is_code128_emulation Whether to use Code128 emulation for MicroPdf417.
      */
-    public function __construct($barcode_type, $data, $data_type = null, $image_format = null, $text_location = null, $foreground_color = null, $background_color = null, $units = null, $resolution = null, $image_height = null, $image_width = null, $rotation_angle = null)
+    public function __construct($barcode_type, $data, $data_type = null, $image_format = null, $text_location = null, $foreground_color = null, $background_color = null, $units = null, $resolution = null, $image_height = null, $image_width = null, $rotation_angle = null, $qr_encode_mode = null, $qr_error_level = null, $qr_version = null, $qr_eci_encoding = null, $qr_aspect_ratio = null, $micro_qr_version = null, $rect_micro_qr_version = null, $code128_encode_mode = null, $pdf417_encode_mode = null, $pdf417_error_level = null, $pdf417_truncate = null, $pdf417_columns = null, $pdf417_rows = null, $pdf417_aspect_ratio = null, $pdf417_eci_encoding = null, $pdf417_is_reader_initialization = null, $pdf417_macro_characters = null, $pdf417_is_linked = null, $pdf417_is_code128_emulation = null)
     {
         $this->barcode_type = $barcode_type;
         $this->data = $data;
@@ -47,6 +66,25 @@ class GenerateRequestWrapper
         $this->image_height = $image_height;
         $this->image_width = $image_width;
         $this->rotation_angle = $rotation_angle;
+        $this->qr_encode_mode = $qr_encode_mode;
+        $this->qr_error_level = $qr_error_level;
+        $this->qr_version = $qr_version;
+        $this->qr_eci_encoding = $qr_eci_encoding;
+        $this->qr_aspect_ratio = $qr_aspect_ratio;
+        $this->micro_qr_version = $micro_qr_version;
+        $this->rect_micro_qr_version = $rect_micro_qr_version;
+        $this->code128_encode_mode = $code128_encode_mode;
+        $this->pdf417_encode_mode = $pdf417_encode_mode;
+        $this->pdf417_error_level = $pdf417_error_level;
+        $this->pdf417_truncate = $pdf417_truncate;
+        $this->pdf417_columns = $pdf417_columns;
+        $this->pdf417_rows = $pdf417_rows;
+        $this->pdf417_aspect_ratio = $pdf417_aspect_ratio;
+        $this->pdf417_eci_encoding = $pdf417_eci_encoding;
+        $this->pdf417_is_reader_initialization = $pdf417_is_reader_initialization;
+        $this->pdf417_macro_characters = $pdf417_macro_characters;
+        $this->pdf417_is_linked = $pdf417_is_linked;
+        $this->pdf417_is_code128_emulation = $pdf417_is_code128_emulation;
     }
 
     /**
@@ -55,7 +93,7 @@ class GenerateRequestWrapper
     public $barcode_type;
 
     /**
-     * String represents data to encode
+     * String that represents the data to encode.
      */
     public $data;
 
@@ -65,47 +103,142 @@ class GenerateRequestWrapper
     public $data_type;
 
     /**
-     * Barcode output image format. Default value: png
+     * Barcode output image format. Default value: png.
      */
     public $image_format;
 
     /**
-     * Specify the displaying Text Location, set to CodeLocation.None to hide CodeText. Default value: Depends on BarcodeType. CodeLocation.Below for 1D Barcodes. CodeLocation.None for 2D Barcodes.
+     * Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes.
      */
     public $text_location;
 
     /**
-     * Specify the displaying bars and content Color. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: Black.
+     * Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
      */
     public $foreground_color;
 
     /**
-     * Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value started with #. For example: AliceBlue or #FF000000 Default value: White.
+     * Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
      */
     public $background_color;
 
     /**
-     * Common Units for all measuring in query. Default units: pixel.
+     * Common units for all measurements. Default units: pixels.
      */
     public $units;
 
     /**
-     * Resolution of the BarCode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is dot.
+     * Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
      */
     public $resolution;
 
     /**
-     * Height of the barcode image in given units. Default units: pixel. Decimal separator is dot.
+     * Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
      */
     public $image_height;
 
     /**
-     * Width of the barcode image in given units. Default units: pixel. Decimal separator is dot.
+     * Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
      */
     public $image_width;
 
     /**
-     * BarCode image rotation angle, measured in degree, e.g. RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle NOT equal to 90, 180, 270 or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
+     * Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
      */
     public $rotation_angle;
+
+    /**
+     * QR barcode encode mode.
+     */
+    public $qr_encode_mode;
+
+    /**
+     * QR barcode error correction level.
+     */
+    public $qr_error_level;
+
+    /**
+     * QR barcode version. Automatically selects the smallest version that fits the data.
+     */
+    public $qr_version;
+
+    /**
+     * ECI encoding for QR barcode data.
+     */
+    public $qr_eci_encoding;
+
+    /**
+     * QR barcode aspect ratio. Values: 0 to 1.
+     */
+    public $qr_aspect_ratio;
+
+    /**
+     * MicroQR barcode version. Used when BarcodeType is MicroQR.
+     */
+    public $micro_qr_version;
+
+    /**
+     * RectMicroQR barcode version. Used when BarcodeType is RectMicroQR.
+     */
+    public $rect_micro_qr_version;
+
+    /**
+     * Code128 barcode encode mode. Controls which Code 128 subset (A, B, C, or mix) is used.
+     */
+    public $code128_encode_mode;
+
+    /**
+     * PDF417 barcode encode mode.
+     */
+    public $pdf417_encode_mode;
+
+    /**
+     * PDF417 barcode error correction level.
+     */
+    public $pdf417_error_level;
+
+    /**
+     * Whether to use truncated PDF417 format (removes right-side stop pattern).
+     */
+    public $pdf417_truncate;
+
+    /**
+     * Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
+     */
+    public $pdf417_columns;
+
+    /**
+     * Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
+     */
+    public $pdf417_rows;
+
+    /**
+     * PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
+     */
+    public $pdf417_aspect_ratio;
+
+    /**
+     * ECI encoding for PDF417 barcode data.
+     */
+    public $pdf417_eci_encoding;
+
+    /**
+     * Whether the barcode is used for reader initialization (programming).
+     */
+    public $pdf417_is_reader_initialization;
+
+    /**
+     * Macro character to prepend (structured append).
+     */
+    public $pdf417_macro_characters;
+
+    /**
+     * Whether to use linked mode (for MicroPdf417).
+     */
+    public $pdf417_is_linked;
+
+    /**
+     * Whether to use Code128 emulation for MicroPdf417.
+     */
+    public $pdf417_is_code128_emulation;
 }

--- a/src/Aspose/BarCode/Requests/GenerateRequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/GenerateRequestWrapper.php
@@ -23,68 +23,20 @@ class GenerateRequestWrapper
      * @param \Aspose\BarCode\Model\EncodeBarcodeType $barcode_type Type of barcode to generate.
      * @param string $data String that represents the data to encode.
      * @param \Aspose\BarCode\Model\EncodeDataType $data_type Type of data to encode. Default value: StringData.
-     * @param \Aspose\BarCode\Model\BarcodeImageFormat $image_format Barcode output image format. Default value: png.
-     * @param \Aspose\BarCode\Model\CodeLocation $text_location Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes.
-     * @param string $foreground_color Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
-     * @param string $background_color Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
-     * @param \Aspose\BarCode\Model\GraphicsUnit $units Common units for all measurements. Default units: pixels.
-     * @param float $resolution Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
-     * @param float $image_height Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
-     * @param float $image_width Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
-     * @param int $rotation_angle Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
-     * @param \Aspose\BarCode\Model\QREncodeMode $qr_encode_mode QR barcode encode mode.
-     * @param \Aspose\BarCode\Model\QRErrorLevel $qr_error_level QR barcode error correction level.
-     * @param \Aspose\BarCode\Model\QRVersion $qr_version QR barcode version. Automatically selects the smallest version that fits the data.
-     * @param \Aspose\BarCode\Model\ECIEncodings $qr_eci_encoding ECI encoding for QR barcode data.
-     * @param float $qr_aspect_ratio QR barcode aspect ratio. Values: 0 to 1.
-     * @param \Aspose\BarCode\Model\MicroQRVersion $micro_qr_version MicroQR barcode version. Used when BarcodeType is MicroQR.
-     * @param \Aspose\BarCode\Model\RectMicroQRVersion $rect_micro_qr_version RectMicroQR barcode version. Used when BarcodeType is RectMicroQR.
-     * @param \Aspose\BarCode\Model\Code128EncodeMode $code128_encode_mode Code128 barcode encode mode. Controls which Code 128 subset (A, B, C, or mix) is used.
-     * @param \Aspose\BarCode\Model\Pdf417EncodeMode $pdf417_encode_mode PDF417 barcode encode mode.
-     * @param \Aspose\BarCode\Model\Pdf417ErrorLevel $pdf417_error_level PDF417 barcode error correction level.
-     * @param bool $pdf417_truncate Whether to use truncated PDF417 format (removes right-side stop pattern).
-     * @param int $pdf417_columns Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
-     * @param int $pdf417_rows Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
-     * @param float $pdf417_aspect_ratio PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
-     * @param \Aspose\BarCode\Model\ECIEncodings $pdf417_eci_encoding ECI encoding for PDF417 barcode data.
-     * @param bool $pdf417_is_reader_initialization Whether the barcode is used for reader initialization (programming).
-     * @param \Aspose\BarCode\Model\MacroCharacter $pdf417_macro_characters Macro character to prepend (structured append).
-     * @param bool $pdf417_is_linked Whether to use linked mode (for MicroPdf417).
-     * @param bool $pdf417_is_code128_emulation Whether to use Code128 emulation for MicroPdf417.
+     * @param \Aspose\BarCode\Model\BarcodeImageParams $barcode_image_params Grouped parameters for BarcodeImageParams.
+     * @param \Aspose\BarCode\Model\QrParams $qr_params Grouped parameters for QrParams.
+     * @param \Aspose\BarCode\Model\Code128Params $code128_params Grouped parameters for Code128Params.
+     * @param \Aspose\BarCode\Model\Pdf417Params $pdf417_params Grouped parameters for Pdf417Params.
      */
-    public function __construct($barcode_type, $data, $data_type = null, $image_format = null, $text_location = null, $foreground_color = null, $background_color = null, $units = null, $resolution = null, $image_height = null, $image_width = null, $rotation_angle = null, $qr_encode_mode = null, $qr_error_level = null, $qr_version = null, $qr_eci_encoding = null, $qr_aspect_ratio = null, $micro_qr_version = null, $rect_micro_qr_version = null, $code128_encode_mode = null, $pdf417_encode_mode = null, $pdf417_error_level = null, $pdf417_truncate = null, $pdf417_columns = null, $pdf417_rows = null, $pdf417_aspect_ratio = null, $pdf417_eci_encoding = null, $pdf417_is_reader_initialization = null, $pdf417_macro_characters = null, $pdf417_is_linked = null, $pdf417_is_code128_emulation = null)
+    public function __construct($barcode_type, $data, $data_type = null, $barcode_image_params = null, $qr_params = null, $code128_params = null, $pdf417_params = null)
     {
         $this->barcode_type = $barcode_type;
         $this->data = $data;
         $this->data_type = $data_type;
-        $this->image_format = $image_format;
-        $this->text_location = $text_location;
-        $this->foreground_color = $foreground_color;
-        $this->background_color = $background_color;
-        $this->units = $units;
-        $this->resolution = $resolution;
-        $this->image_height = $image_height;
-        $this->image_width = $image_width;
-        $this->rotation_angle = $rotation_angle;
-        $this->qr_encode_mode = $qr_encode_mode;
-        $this->qr_error_level = $qr_error_level;
-        $this->qr_version = $qr_version;
-        $this->qr_eci_encoding = $qr_eci_encoding;
-        $this->qr_aspect_ratio = $qr_aspect_ratio;
-        $this->micro_qr_version = $micro_qr_version;
-        $this->rect_micro_qr_version = $rect_micro_qr_version;
-        $this->code128_encode_mode = $code128_encode_mode;
-        $this->pdf417_encode_mode = $pdf417_encode_mode;
-        $this->pdf417_error_level = $pdf417_error_level;
-        $this->pdf417_truncate = $pdf417_truncate;
-        $this->pdf417_columns = $pdf417_columns;
-        $this->pdf417_rows = $pdf417_rows;
-        $this->pdf417_aspect_ratio = $pdf417_aspect_ratio;
-        $this->pdf417_eci_encoding = $pdf417_eci_encoding;
-        $this->pdf417_is_reader_initialization = $pdf417_is_reader_initialization;
-        $this->pdf417_macro_characters = $pdf417_macro_characters;
-        $this->pdf417_is_linked = $pdf417_is_linked;
-        $this->pdf417_is_code128_emulation = $pdf417_is_code128_emulation;
+        $this->barcode_image_params = $barcode_image_params;
+        $this->qr_params = $qr_params;
+        $this->code128_params = $code128_params;
+        $this->pdf417_params = $pdf417_params;
     }
 
     /**
@@ -103,142 +55,30 @@ class GenerateRequestWrapper
     public $data_type;
 
     /**
-     * Barcode output image format. Default value: png.
+     * Grouped parameters for BarcodeImageParams.
+     *
+     * @var \Aspose\BarCode\Model\BarcodeImageParams|null
      */
-    public $image_format;
+    public $barcode_image_params;
 
     /**
-     * Specify the displayed text location. Set to CodeLocation.None to hide CodeText. Default value depends on BarcodeType: CodeLocation.Below for 1D barcodes and CodeLocation.None for 2D barcodes.
+     * Grouped parameters for QrParams.
+     *
+     * @var \Aspose\BarCode\Model\QrParams|null
      */
-    public $text_location;
+    public $qr_params;
 
     /**
-     * Specify the display color for bars and content. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: Black.
+     * Grouped parameters for Code128Params.
+     *
+     * @var \Aspose\BarCode\Model\Code128Params|null
      */
-    public $foreground_color;
+    public $code128_params;
 
     /**
-     * Background color of the barcode image. Value: Color name from https://reference.aspose.com/drawing/net/system.drawing/color/ or ARGB value starting with #. For example: AliceBlue or #FF000000. Default value: White.
+     * Grouped parameters for Pdf417Params.
+     *
+     * @var \Aspose\BarCode\Model\Pdf417Params|null
      */
-    public $background_color;
-
-    /**
-     * Common units for all measurements. Default units: pixels.
-     */
-    public $units;
-
-    /**
-     * Resolution of the barcode image. One value for both dimensions. Default value: 96 dpi. Decimal separator is a dot.
-     */
-    public $resolution;
-
-    /**
-     * Height of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
-     */
-    public $image_height;
-
-    /**
-     * Width of the barcode image in the specified units. Default units: pixels. Decimal separator is a dot.
-     */
-    public $image_width;
-
-    /**
-     * Barcode image rotation angle, measured in degrees. For example, RotationAngle = 0 or RotationAngle = 360 means no rotation. If RotationAngle is not equal to 90, 180, 270, or 0, it may increase the difficulty for the scanner to read the image. Default value: 0.
-     */
-    public $rotation_angle;
-
-    /**
-     * QR barcode encode mode.
-     */
-    public $qr_encode_mode;
-
-    /**
-     * QR barcode error correction level.
-     */
-    public $qr_error_level;
-
-    /**
-     * QR barcode version. Automatically selects the smallest version that fits the data.
-     */
-    public $qr_version;
-
-    /**
-     * ECI encoding for QR barcode data.
-     */
-    public $qr_eci_encoding;
-
-    /**
-     * QR barcode aspect ratio. Values: 0 to 1.
-     */
-    public $qr_aspect_ratio;
-
-    /**
-     * MicroQR barcode version. Used when BarcodeType is MicroQR.
-     */
-    public $micro_qr_version;
-
-    /**
-     * RectMicroQR barcode version. Used when BarcodeType is RectMicroQR.
-     */
-    public $rect_micro_qr_version;
-
-    /**
-     * Code128 barcode encode mode. Controls which Code 128 subset (A, B, C, or mix) is used.
-     */
-    public $code128_encode_mode;
-
-    /**
-     * PDF417 barcode encode mode.
-     */
-    public $pdf417_encode_mode;
-
-    /**
-     * PDF417 barcode error correction level.
-     */
-    public $pdf417_error_level;
-
-    /**
-     * Whether to use truncated PDF417 format (removes right-side stop pattern).
-     */
-    public $pdf417_truncate;
-
-    /**
-     * Number of columns in the PDF417 barcode. Values between 1 and 30. 0 for auto.
-     */
-    public $pdf417_columns;
-
-    /**
-     * Number of rows in the PDF417 barcode. Values between 3 and 90. 0 for automatic.
-     */
-    public $pdf417_rows;
-
-    /**
-     * PDF417 barcode aspect ratio (height/width of the barcode module). Values are defined by the standard: 2 to 5 for MicroPdf417; 3 to 5 for Pdf417 and MacroPdf417.
-     */
-    public $pdf417_aspect_ratio;
-
-    /**
-     * ECI encoding for PDF417 barcode data.
-     */
-    public $pdf417_eci_encoding;
-
-    /**
-     * Whether the barcode is used for reader initialization (programming).
-     */
-    public $pdf417_is_reader_initialization;
-
-    /**
-     * Macro character to prepend (structured append).
-     */
-    public $pdf417_macro_characters;
-
-    /**
-     * Whether to use linked mode (for MicroPdf417).
-     */
-    public $pdf417_is_linked;
-
-    /**
-     * Whether to use Code128 emulation for MicroPdf417.
-     */
-    public $pdf417_is_code128_emulation;
+    public $pdf417_params;
 }

--- a/src/Aspose/BarCode/Requests/RecognizeBase64RequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/RecognizeBase64RequestWrapper.php
@@ -20,7 +20,7 @@ class RecognizeBase64RequestWrapper
     /**
      * Initializes a new instance of the RecognizeBase64RequestWrapper class.
      *
-     * @param \Aspose\BarCode\Model\RecognizeBase64Request $recognize_base64_request Barcode recognition request
+     * @param \Aspose\BarCode\Model\RecognizeBase64Request $recognize_base64_request Barcode recognition request.
      */
     public function __construct($recognize_base64_request)
     {
@@ -28,7 +28,7 @@ class RecognizeBase64RequestWrapper
     }
 
     /**
-     * Barcode recognition request
+     * Barcode recognition request.
      */
     public $recognize_base64_request;
 }

--- a/src/Aspose/BarCode/Requests/RecognizeMultipartRequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/RecognizeMultipartRequestWrapper.php
@@ -20,10 +20,10 @@ class RecognizeMultipartRequestWrapper
     /**
      * Initializes a new instance of the RecognizeMultipartRequestWrapper class.
      *
-     * @param \Aspose\BarCode\Model\DecodeBarcodeType $barcode_type
+     * @param \Aspose\BarCode\Model\DecodeBarcodeType $barcode_type See https://reference.aspose.com/barcode/net/aspose.barcode.barcoderecognition/decodetype/
      * @param \SplFileObject $file Barcode image file.
-     * @param \Aspose\BarCode\Model\RecognitionMode $recognition_mode
-     * @param \Aspose\BarCode\Model\RecognitionImageKind $recognition_image_kind
+     * @param \Aspose\BarCode\Model\RecognitionMode $recognition_mode Recognition mode.
+     * @param \Aspose\BarCode\Model\RecognitionImageKind $recognition_image_kind Image kind for recognition.
      */
     public function __construct($barcode_type, $file, $recognition_mode = null, $recognition_image_kind = null)
     {
@@ -34,7 +34,7 @@ class RecognizeMultipartRequestWrapper
     }
 
     /**
-     * Gets or sets barcode_type
+     * See https://reference.aspose.com/barcode/net/aspose.barcode.barcoderecognition/decodetype/
      */
     public $barcode_type;
 
@@ -44,12 +44,12 @@ class RecognizeMultipartRequestWrapper
     public $file;
 
     /**
-     * Gets or sets recognition_mode
+     * Recognition mode.
      */
     public $recognition_mode;
 
     /**
-     * Gets or sets recognition_image_kind
+     * Image kind for recognition.
      */
     public $recognition_image_kind;
 }

--- a/src/Aspose/BarCode/Requests/RecognizeMultipartRequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/RecognizeMultipartRequestWrapper.php
@@ -21,7 +21,7 @@ class RecognizeMultipartRequestWrapper
      * Initializes a new instance of the RecognizeMultipartRequestWrapper class.
      *
      * @param \Aspose\BarCode\Model\DecodeBarcodeType $barcode_type
-     * @param \SplFileObject $file Barcode image file
+     * @param \SplFileObject $file Barcode image file.
      * @param \Aspose\BarCode\Model\RecognitionMode $recognition_mode
      * @param \Aspose\BarCode\Model\RecognitionImageKind $recognition_image_kind
      */
@@ -39,7 +39,7 @@ class RecognizeMultipartRequestWrapper
     public $barcode_type;
 
     /**
-     * Barcode image file
+     * Barcode image file.
      */
     public $file;
 

--- a/src/Aspose/BarCode/Requests/RecognizeRequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/RecognizeRequestWrapper.php
@@ -20,10 +20,10 @@ class RecognizeRequestWrapper
     /**
      * Initializes a new instance of the RecognizeRequestWrapper class.
      *
-     * @param \Aspose\BarCode\Model\DecodeBarcodeType $barcode_type Type of barcode to recognize
-     * @param string $file_url Url to barcode image
-     * @param \Aspose\BarCode\Model\RecognitionMode $recognition_mode Recognition mode
-     * @param \Aspose\BarCode\Model\RecognitionImageKind $recognition_image_kind Image kind for recognition
+     * @param \Aspose\BarCode\Model\DecodeBarcodeType $barcode_type Type of barcode to recognize.
+     * @param string $file_url URL to the barcode image.
+     * @param \Aspose\BarCode\Model\RecognitionMode $recognition_mode Recognition mode.
+     * @param \Aspose\BarCode\Model\RecognitionImageKind $recognition_image_kind Image kind for recognition.
      */
     public function __construct($barcode_type, $file_url, $recognition_mode = null, $recognition_image_kind = null)
     {
@@ -34,22 +34,22 @@ class RecognizeRequestWrapper
     }
 
     /**
-     * Type of barcode to recognize
+     * Type of barcode to recognize.
      */
     public $barcode_type;
 
     /**
-     * Url to barcode image
+     * URL to the barcode image.
      */
     public $file_url;
 
     /**
-     * Recognition mode
+     * Recognition mode.
      */
     public $recognition_mode;
 
     /**
-     * Image kind for recognition
+     * Image kind for recognition.
      */
     public $recognition_image_kind;
 }

--- a/src/Aspose/BarCode/Requests/ScanBase64RequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/ScanBase64RequestWrapper.php
@@ -20,7 +20,7 @@ class ScanBase64RequestWrapper
     /**
      * Initializes a new instance of the ScanBase64RequestWrapper class.
      *
-     * @param \Aspose\BarCode\Model\ScanBase64Request $scan_base64_request Barcode scan request
+     * @param \Aspose\BarCode\Model\ScanBase64Request $scan_base64_request Barcode scan request.
      */
     public function __construct($scan_base64_request)
     {
@@ -28,7 +28,7 @@ class ScanBase64RequestWrapper
     }
 
     /**
-     * Barcode scan request
+     * Barcode scan request.
      */
     public $scan_base64_request;
 }

--- a/src/Aspose/BarCode/Requests/ScanMultipartRequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/ScanMultipartRequestWrapper.php
@@ -20,7 +20,7 @@ class ScanMultipartRequestWrapper
     /**
      * Initializes a new instance of the ScanMultipartRequestWrapper class.
      *
-     * @param \SplFileObject $file Barcode image file
+     * @param \SplFileObject $file Barcode image file.
      */
     public function __construct($file)
     {
@@ -28,7 +28,7 @@ class ScanMultipartRequestWrapper
     }
 
     /**
-     * Barcode image file
+     * Barcode image file.
      */
     public $file;
 }

--- a/src/Aspose/BarCode/Requests/ScanRequestWrapper.php
+++ b/src/Aspose/BarCode/Requests/ScanRequestWrapper.php
@@ -20,7 +20,7 @@ class ScanRequestWrapper
     /**
      * Initializes a new instance of the ScanRequestWrapper class.
      *
-     * @param string $file_url Url to barcode image
+     * @param string $file_url URL to the barcode image.
      */
     public function __construct($file_url)
     {
@@ -28,7 +28,7 @@ class ScanRequestWrapper
     }
 
     /**
-     * Url to barcode image
+     * URL to the barcode image.
      */
     public $file_url;
 }

--- a/src/Aspose/BarCode/ScanApi.php
+++ b/src/Aspose/BarCode/ScanApi.php
@@ -90,7 +90,7 @@ class ScanApi
     /**
      * Operation scan
      *
-     * Scan barcode from file on server in the Internet using GET requests with parameter in query string. For scaning files from your hard drive use `scan-body` or `scan-multipart` endpoints instead.
+     * Scan a barcode from a file on an Internet server using a GET request with a query string parameter. For scanning files from your hard drive, use `scan-body` or `scan-multipart` endpoints instead.
      *
      * @param Requests\ScanRequestWrapper $request is a request object for operation
      *
@@ -112,7 +112,7 @@ class ScanApi
     /**
      * Operation scanWithHttpInfo
      *
-     * Scan barcode from file on server in the Internet using GET requests with parameter in query string. For scaning files from your hard drive use `scan-body` or `scan-multipart` endpoints instead.
+     * Scan a barcode from a file on an Internet server using a GET request with a query string parameter. For scanning files from your hard drive, use `scan-body` or `scan-multipart` endpoints instead.
      *
      * @param Requests\ScanRequestWrapper $request is a request object for operation
      *
@@ -176,7 +176,7 @@ class ScanApi
     /**
      * Operation scanAsync
      *
-     * Scan barcode from file on server in the Internet using GET requests with parameter in query string. For scaning files from your hard drive use `scan-body` or `scan-multipart` endpoints instead.
+     * Scan a barcode from a file on an Internet server using a GET request with a query string parameter. For scanning files from your hard drive, use `scan-body` or `scan-multipart` endpoints instead.
      *
      * @param Requests\ScanRequestWrapper $request is a request object for operation
      *
@@ -196,7 +196,7 @@ class ScanApi
     /**
      * Operation scanAsyncWithHttpInfo
      *
-     * Scan barcode from file on server in the Internet using GET requests with parameter in query string. For scaning files from your hard drive use `scan-body` or `scan-multipart` endpoints instead.
+     * Scan a barcode from a file on an Internet server using a GET request with a query string parameter. For scanning files from your hard drive, use `scan-body` or `scan-multipart` endpoints instead.
      *
      * @param Requests\ScanRequestWrapper $request is a request object for operation
      *
@@ -334,7 +334,7 @@ class ScanApi
     /**
      * Operation scanBase64
      *
-     * Scan barcode from file in request body using POST requests with parameter in body in json or xml format.
+     * Scan a barcode from a file in the request body using a POST request with a JSON or XML body parameter.
      *
      * @param Requests\ScanBase64RequestWrapper $request is a request object for operation
      *
@@ -356,7 +356,7 @@ class ScanApi
     /**
      * Operation scanBase64WithHttpInfo
      *
-     * Scan barcode from file in request body using POST requests with parameter in body in json or xml format.
+     * Scan a barcode from a file in the request body using a POST request with a JSON or XML body parameter.
      *
      * @param Requests\ScanBase64RequestWrapper $request is a request object for operation
      *
@@ -420,7 +420,7 @@ class ScanApi
     /**
      * Operation scanBase64Async
      *
-     * Scan barcode from file in request body using POST requests with parameter in body in json or xml format.
+     * Scan a barcode from a file in the request body using a POST request with a JSON or XML body parameter.
      *
      * @param Requests\ScanBase64RequestWrapper $request is a request object for operation
      *
@@ -440,7 +440,7 @@ class ScanApi
     /**
      * Operation scanBase64AsyncWithHttpInfo
      *
-     * Scan barcode from file in request body using POST requests with parameter in body in json or xml format.
+     * Scan a barcode from a file in the request body using a POST request with a JSON or XML body parameter.
      *
      * @param Requests\ScanBase64RequestWrapper $request is a request object for operation
      *
@@ -582,7 +582,7 @@ class ScanApi
     /**
      * Operation scanMultipart
      *
-     * Scan barcode from file in request body using POST requests with parameter in multipart form.
+     * Scan a barcode from a file in the request body using a POST request with a multipart form parameter.
      *
      * @param Requests\ScanMultipartRequestWrapper $request is a request object for operation
      *
@@ -604,7 +604,7 @@ class ScanApi
     /**
      * Operation scanMultipartWithHttpInfo
      *
-     * Scan barcode from file in request body using POST requests with parameter in multipart form.
+     * Scan a barcode from a file in the request body using a POST request with a multipart form parameter.
      *
      * @param Requests\ScanMultipartRequestWrapper $request is a request object for operation
      *
@@ -668,7 +668,7 @@ class ScanApi
     /**
      * Operation scanMultipartAsync
      *
-     * Scan barcode from file in request body using POST requests with parameter in multipart form.
+     * Scan a barcode from a file in the request body using a POST request with a multipart form parameter.
      *
      * @param Requests\ScanMultipartRequestWrapper $request is a request object for operation
      *
@@ -688,7 +688,7 @@ class ScanApi
     /**
      * Operation scanMultipartAsyncWithHttpInfo
      *
-     * Scan barcode from file in request body using POST requests with parameter in multipart form.
+     * Scan a barcode from a file in the request body using a POST request with a multipart form parameter.
      *
      * @param Requests\ScanMultipartRequestWrapper $request is a request object for operation
      *

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -8,6 +8,7 @@ use Aspose\BarCode\Model\DecodeBarcodeType;
 use Aspose\BarCode\Model\EncodeBarcodeType;
 use Aspose\BarCode\Model\EncodeDataType;
 use Aspose\BarCode\Model\BarcodeImageFormat;
+use Aspose\BarCode\Model\BarcodeImageParams;
 use Aspose\BarCode\Requests\GenerateRequestWrapper;
 use Aspose\BarCode\Requests\ScanMultipartRequestWrapper;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +26,8 @@ final class EndToEndTest extends TestCase
 
         // Generate
         $genRequest = new GenerateRequestWrapper(EncodeBarcodeType::QR, 'PHP SDK Test');
-        $genRequest->image_format = BarcodeImageFormat::Png;
+        $genRequest->barcode_image_params = new BarcodeImageParams();
+        $genRequest->barcode_image_params->setImageFormat(BarcodeImageFormat::Png);
 
         $genResponse = $genApi->generate($genRequest);
 

--- a/tests/GenerateApiTest.php
+++ b/tests/GenerateApiTest.php
@@ -78,7 +78,8 @@ class GenerateApiTest extends TestCase
     public function testBarcodeGenerateBarcodeTypeGet()
     {
         $request = new GenerateRequestWrapper(EncodeBarcodeType::QR, 'PHP SDK Test');
-        $request->image_format = BarcodeImageFormat::Png;
+        $request->barcode_image_params = new BarcodeImageParams();
+        $request->barcode_image_params->setImageFormat(BarcodeImageFormat::Png);
 
         $response = self::$api->generate($request);
 


### PR DESCRIPTION
## Summary
- regenerate SDK from the updated Cloud API v4.0 specification for the June release
- add generated barcode parameter models and docs for the new QR/PDF417/Code128 options
- update README examples and snippets to cover the new generation parameters

## Validation
- local generation completed with `make sdk`
- SDK build/lint smoke checks were run before opening this PR

No deployment is included in this PR.